### PR TITLE
Fix loop reload to keep execution in thread with updated tests

### DIFF
--- a/ovos_dinkum_listener/voice_loop/hotwords.py
+++ b/ovos_dinkum_listener/voice_loop/hotwords.py
@@ -219,8 +219,6 @@ class HotwordContainer:
         # streaming engines will ignore the byte_data
         audio_data = self.audio_buffer.get()
         for ww_name, engine in engines.items():
-            # Checking for hey_neon in 96000 chunks
-            # LOG.debug(f"Checking for {ww_name} in {len(audio_data)} chunks")
             try:
                 assert isinstance(engine, HotWordEngine)
                 # non-streaming ww engines expect a 3-second cyclic buffer here
@@ -232,6 +230,7 @@ class HotwordContainer:
             except AssertionError:
                 LOG.error(f"Expected HotWordEngine, but got: {engine} for "
                           f"{ww_name}")
+                # TODO: Add engine reload here?
             except Exception as e:
                 LOG.error(e)
         return None


### PR DESCRIPTION
Updates config reload handling to defer loop.run to the original thread so shutdown works as expected
Enables timeout on lock acquisition in `reload_configuration` to raise an exception after timeout instead of waiting infinitely