### PR TITLE
Raise instead of just logging when no hotword plugin is loaded

### DIFF
--- a/ovos_dinkum_listener/voice_loop/hotwords.py
+++ b/ovos_dinkum_listener/voice_loop/hotwords.py
@@ -205,12 +205,11 @@ class HotwordContainer:
             engines = self.listen_words
             if not engines:
                 raise RuntimeWarning(
-                    f"Waiting for listen_words but none are Available!")
+                    f"Waiting for listen_words but none are available!")
         elif self.state == HotwordState.WAKEUP:
             engines = self.wakeup_words
             if not engines:
-                raise RuntimeWarning(
-                    f"Waiting for wakeup_words but none are Available!")
+                LOG.warning("Waiting for wakeup_words but none are available!")
         elif self.state == HotwordState.RECORDING:
             engines = self.stop_words
             if not engines:

--- a/ovos_dinkum_listener/voice_loop/hotwords.py
+++ b/ovos_dinkum_listener/voice_loop/hotwords.py
@@ -159,6 +159,13 @@ class HotwordContainer:
             except Exception as e:
                 LOG.error("Failed to load hotword: " + word)
 
+        if not self.listen_words:
+            LOG.error("No listen words loaded")
+        if not self.wakeup_words:
+            LOG.warning("No wakeup words loaded")
+        if not self.stop_words:
+            LOG.warning("No stop words loaded")
+
     @property
     def ww_names(self):
         """ wakeup words exit sleep mode if detected after a listen word"""
@@ -208,12 +215,8 @@ class HotwordContainer:
                     f"Waiting for listen_words but none are available!")
         elif self.state == HotwordState.WAKEUP:
             engines = self.wakeup_words
-            if not engines:
-                LOG.warning("Waiting for wakeup_words but none are available!")
         elif self.state == HotwordState.RECORDING:
             engines = self.stop_words
-            if not engines:
-                LOG.debug("No stop_words loaded")
         else:
             engines = self.hot_words
 

--- a/ovos_dinkum_listener/voice_loop/hotwords.py
+++ b/ovos_dinkum_listener/voice_loop/hotwords.py
@@ -204,11 +204,13 @@ class HotwordContainer:
         if self.state == HotwordState.LISTEN:
             engines = self.listen_words
             if not engines:
-                LOG.debug("No listen_words loaded")
+                raise RuntimeWarning(
+                    f"Waiting for listen_words but none are Available!")
         elif self.state == HotwordState.WAKEUP:
             engines = self.wakeup_words
             if not engines:
-                LOG.debug("No wakeup_words loaded")
+                raise RuntimeWarning(
+                    f"Waiting for wakeup_words but none are Available!")
         elif self.state == HotwordState.RECORDING:
             engines = self.stop_words
             if not engines:


### PR DESCRIPTION
If waiting for a listen word, raise if no WW is configured
If waiting for a wakeup word, raise if no wakeup word is configured
Closes #33