### PR TITLE
Add missing setup.py contents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,20 @@ def get_version():
     return version
 
 
+def get_description():
+    with open(os.path.join(BASEDIR, "README.md"), "r") as f:
+        long_description = f.read()
+    return long_description
+
+
 setup(
     name='ovos-dinkum-listener',
     version=get_version(),
     license='Apache-2.0',
     url='https://github.com/OpenVoiceOS/ovos-dinkum-listener',
     description='ovos-core listener daemon client',
+    long_description=get_description(),
+    long_description_content_type="text/markdown",
     packages=['ovos_dinkum_listener'],
     package_data={'': package_files('ovos_dinkum_listener')},
     include_package_data=True,


### PR DESCRIPTION
Add `long_description` and `long_description_content_type` to setup.py to resolve PyPI publication failure
https://github.com/OpenVoiceOS/ovos-dinkum-listener/actions/runs/5686014800/job/15412056005