### PR TITLE
Fix README.MD and Added Timeout_Seconds_With_Silence

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,19 @@ eg, to run under MacOS you should use https://github.com/OpenVoiceOS/ovos-microp
       "module": "ovos-microphone-plugin-alsa"
     },
     VAD": {
-     // Seconds of speech before voice command has begun
-     "speech_seconds": 0.1,
-     // Seconds of silence before a voice command has finished
-     "silence_seconds": 0.5,
-     // Seconds of audio to keep before voice command has begun
-     "before_seconds": 0.5,
-     // Minimum length of voice command (seconds)
-     // NOTE: max_seconds uses recording_timeout listener setting
-     "min_seconds": 1,
      // recommended plugin: "ovos-vad-plugin-silero"
-     "module": "ovos-vad-plugin-webrtcvad",
+     "module": "ovos-vad-plugin-silero",
      "ovos-vad-plugin-silero": {"threshold": 0.2},
      "ovos-vad-plugin-webrtcvad": {"vad_mode": 3}
     },
-    // Settings used by microphone to set recording timeout
+    // Seconds of speech before voice command has begun
+    "speech_begin": 0.1,
+    // Seconds of silence before a voice command has finished
+    "silence_end": 0.5,
+    // Settings used by microphone to set recording timeout with and without speech detected
     "recording_timeout": 10.0,
+    // Settings used by microphone to set recording timeout without speech detected.
     "recording_timeout_with_silence": 3.0,
-
     // continuous listen is an experimental setting, it removes the need for
     // wake words and uses VAD only, a streaming STT is strongly recommended
     // NOTE: depending on hardware this may cause mycroft to hear its own TTS responses as questions

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -210,6 +210,7 @@ class OVOSDinkumVoiceService(Thread):
                 speech_seconds=listener_config.get("speech_begin", 0.3),
                 silence_seconds=listener_config.get("silence_end", 0.7),
                 timeout_seconds=listener_config.get("recording_timeout", 10),
+                timeout_seconds_with_silence=listener_config.get("recording_timeout_with_silence", 5),                
                 num_stt_rewind_chunks=listener_config.get(
                     "utterance_chunks_to_rewind", 2),
                 num_hotword_keep_chunks=listener_config.get(


### PR DESCRIPTION
Fixed the README.MD to correct the settings used by dinkum-listener.  Made silero the default VAD in the README.MD file.  Added timeout_seconds_with_silence support. 