### PR TITLE
feat extract speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ eg, to run under MacOS you should use https://github.com/OpenVoiceOS/ovos-microp
     "recording_timeout": 10.0,
     // Settings used by microphone to set recording timeout without speech detected.
     "recording_timeout_with_silence": 3.0,
+    // Setting to remove all silence/noise from start and end of recorded speech (only non-streaming)
+    "remove_silence": true,
     // continuous listen is an experimental setting, it removes the need for
     // wake words and uses VAD only, a streaming STT is strongly recommended
     // NOTE: depending on hardware this may cause mycroft to hear its own TTS responses as questions

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -213,6 +213,8 @@ class OVOSDinkumVoiceService(Thread):
                     "utterance_chunks_to_rewind", 2),
                 num_hotword_keep_chunks=listener_config.get(
                     "wakeword_chunks_to_save", 15),
+                remove_silence=listener_config.get(
+                    "remove_silence", False),
                 #
                 wake_callback=self._record_begin,
                 text_callback=self._stt_text,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 ovos-backend-client>=0.1.0a7
-ovos-plugin-manager~=0.0.23
+ovos-plugin-manager>=0.0.24a6
 ovos-microphone-plugin-alsa~=0.0.0
 ovos-utils>=0.0.36a3
 ovos-config~=0.0.10


### PR DESCRIPTION
adds setting `remove_silence` to remove all silence/noise from start and end of recorded speech (only non-streaming)

(a VAD feature introduced with https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/139)