### PR TITLE
feat/validate_message_context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ doc/_build/
 test/unittests/skills/test_skill/settings.json
 test_conf.json
 .pytest_cache/
+/.gtm/


### PR DESCRIPTION
ignore messages targeted to a remote client (eg, hivemind voice sat)

same principle handled in ovos-audio for TTS/audio playback