### PR TITLE
unmute on hotword

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -347,6 +347,8 @@ class OVOSDinkumVoiceService(Thread):
         self.bus.on("opm.ww.query", self._handle_opm_ww_query)
         self.bus.on("opm.vad.query", self._handle_opm_vad_query)
 
+        self.bus.on("mycroft.audio.play_sound.response", self._handle_sound_played)
+
         LOG.debug("Messagebus events registered")
 
     def _after_start(self):
@@ -541,7 +543,10 @@ class OVOSDinkumVoiceService(Thread):
                            }
                 LOG.debug(f"Handling listen sound: {sound}")
                 self.bus.emit(Message("mycroft.audio.play_sound",
-                                      {"uri": sound}, context))
+                                                   {"uri": sound,
+                                                    "force_unmute": True}, context))
+            else:
+                self.voice_loop.cmd_ready = True
 
             if listen:
                 msg_type = "recognizer_loop:wakeword"
@@ -770,6 +775,11 @@ class OVOSDinkumVoiceService(Thread):
         """Wake up the voice loop."""
         self.voice_loop.wakeup()
         self.bus.emit(message.reply("mycroft.awoken"))
+    
+    def _handle_sound_played(self, message: Message):
+        """Handle cmd_ready message from audio service."""
+        if message.context.get("destination") == 'listener':
+            self.voice_loop.cmd_ready = True
 
     # OPM bus api
     def _handle_get_languages_stt(self, message):

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -13,6 +13,7 @@
 import json
 import time
 import wave
+from threading import Timer, Event
 from enum import Enum
 from hashlib import md5
 from ovos_bus_client import Message, MessageBusClient
@@ -543,10 +544,11 @@ class OVOSDinkumVoiceService(Thread):
                            }
                 LOG.debug(f"Handling listen sound: {sound}")
                 self.bus.emit(Message("mycroft.audio.play_sound",
-                                                   {"uri": sound,
-                                                    "force_unmute": True}, context))
-            else:
-                self.voice_loop.cmd_ready = True
+                                      {"uri": sound, "force_unmute": True},
+                                      context))
+                self.voice_loop.state == ListeningState.CONFIRMATION
+                self.voice_loop.confirmation_event.clear()
+                Timer(0.5, lambda: self.voice_loop.confirmation_event.set()).start()
 
             if listen:
                 msg_type = "recognizer_loop:wakeword"
@@ -777,9 +779,9 @@ class OVOSDinkumVoiceService(Thread):
         self.bus.emit(message.reply("mycroft.awoken"))
     
     def _handle_sound_played(self, message: Message):
-        """Handle cmd_ready message from audio service."""
-        if message.context.get("destination") == 'listener':
-            self.voice_loop.cmd_ready = True
+        """Handle response message from audio service."""
+        if self.voice_loop.state == ListeningState.CONFIRMATION:
+            self.voice_loop.confirmation_event.set()
 
     # OPM bus api
     def _handle_get_languages_stt(self, message):

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -246,7 +246,7 @@ class DinkumVoiceLoop(VoiceLoop):
             elif self.state == ListeningState.CHECK_WAKE_UP:
                 self._detect_wakeup(chunk)
             
-            # set 
+            # set either by timeout (0.5) or by ovos-audio response
             elif self.state == ListeningState.CONFIRMATION and \
                     self.confirmation_event.is_set():
                 self.state = ListeningState.BEFORE_COMMAND

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -178,6 +178,7 @@ class DinkumVoiceLoop(VoiceLoop):
         self.timeout_seconds_left = self.timeout_seconds
         self.timeout_seconds_with_silence_left = self.timeout_seconds_with_silence        
         self.state = ListeningState.DETECT_WAKEWORD
+        self.cmd_ready = False
 
         # Keep hotword/STT audio so they can (optionally) be saved to disk
         self.hotword_chunks = deque(maxlen=self.num_hotword_keep_chunks)
@@ -242,7 +243,7 @@ class DinkumVoiceLoop(VoiceLoop):
             elif self.state == ListeningState.CHECK_WAKE_UP:
                 self._detect_wakeup(chunk)
 
-            elif self.state == ListeningState.BEFORE_COMMAND:
+            elif self.state == ListeningState.BEFORE_COMMAND and self.cmd_ready:
                 LOG.debug("waiting for speech")
                 self._before_cmd(chunk)
             elif self.state == ListeningState.IN_COMMAND:
@@ -250,6 +251,7 @@ class DinkumVoiceLoop(VoiceLoop):
                 self._in_cmd(chunk)
             elif self.state == ListeningState.AFTER_COMMAND:
                 LOG.info("speech finished")
+                self.cmd_ready = False
                 self._after_cmd(chunk)
 
             if self.chunk_callback is not None:


### PR DESCRIPTION
Forces an unmute `"force_unmute": True` playing a sound in the audio callback when a hotword is detected. The counterpart PR https://github.com/OpenVoiceOS/ovos-audio/pull/40  will be joining `ovos-audio`

This introduces another voice loop attribute: `cmd_ready` that is normally `False` and gets set when a sound is finished playing (or no sound payed at all). It gets resetted after a command is spoken. With that a continuation of the loop is granted while doing things that have to be done (in this case play sound - but could be X).

Both PRs take advantage of the `muted` flag when polling the volume:  https://github.com/OpenVoiceOS/ovos-PHAL-plugin-alsa/pull/22