### PR TITLE
confirmation state: add handle_listen

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -721,6 +721,9 @@ class OVOSDinkumVoiceService(Thread):
                            }
                 message = message or Message("", context=context)  # might be None
                 self.bus.emit(message.forward("mycroft.audio.play_sound", {"uri": sound}))
+                self.voice_loop.state = ListeningState.CONFIRMATION
+                self.voice_loop.confirmation_event.clear()
+                Timer(0.5, lambda: self.voice_loop.confirmation_event.set()).start()
 
         self.voice_loop.skip_next_wake = True
 


### PR DESCRIPTION
As with #73 , the confirmation state has to be set for "speak and listen"-scenarios (eg. `get_response`)

This sets the condition and adds a 0.5 event set timer to proceed in the voice loop.