### PR TITLE
fix lang detect

### DIFF
--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -604,8 +604,7 @@ class DinkumVoiceLoop(VoiceLoop):
         @return: validated language (or default)
         """
         default_lang = Configuration().get("lang", "en-us")
-        s = SessionManager.get()
-        valid_langs = [l.lower().split("-")[0] for l in s.valid_languages]
+        valid_langs = [l.lower().split("-")[0] for l in [ [default_lang] + Configuration().get("secondary_langs", [])]
         l2 = lang.lower().split("-")[0]
         if l2 in valid_langs:
             if l2 != default_lang.lower().split("-")[0]:

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -604,7 +604,7 @@ class DinkumVoiceLoop(VoiceLoop):
         @return: validated language (or default)
         """
         default_lang = Configuration().get("lang", "en-us")
-        valid_langs = [l.lower().split("-")[0] for l in [ [default_lang] + Configuration().get("secondary_langs", [])]
+        valid_langs = [l.lower().split("-")[0] for l in [default_lang] + Configuration().get("secondary_langs", [])]
         l2 = lang.lower().split("-")[0]
         if l2 in valid_langs:
             if l2 != default_lang.lower().split("-")[0]:

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -604,7 +604,8 @@ class DinkumVoiceLoop(VoiceLoop):
         @return: validated language (or default)
         """
         default_lang = Configuration().get("lang", "en-us")
-        valid_langs = [l.lower().split("-")[0] for l in [default_lang] + Configuration().get("secondary_langs", [])]
+        valid_langs = [default_lang] + Configuration().get("secondary_langs", [])
+        valid_langs = [l.lower().split("-")[0] for l in valid_langs]
         l2 = lang.lower().split("-")[0]
         if l2 in valid_langs:
             if l2 != default_lang.lower().split("-")[0]:


### PR DESCRIPTION
fix  https://github.com/OpenVoiceOS/ovos-dinkum-listener/issues/79
```
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]: Traceback (most recent call last):
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/service.py", line 320, in run
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:     self.voice_loop.run()
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/voice_loop/voice_loop.py", line 267, in run
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:     self._after_cmd(chunk)
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/voice_loop/voice_loop.py", line 674, in _after_cmd
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:     text, stt_context = self._get_tx(stt_context)
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:                         ^^^^^^^^^^^^^^^^^^^^^^^^^
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/voice_loop/voice_loop.py", line 628, in _get_tx
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:     lang = self._validate_lang(stt_context["stt_lang"])
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_dinkum_listener/voice_loop/voice_loop.py", line 608, in _validate_lang
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:     valid_langs = [l.lower().split("-")[0] for l in s.valid_languages]
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]:                                                     ^^^^^^^^^^^^^^^^^
d�c. 07 11:31:00 rpi4b hivemind-voice-sat[11704]: AttributeError: 'Session' object has no attribute 'valid_languages'
```