### PR TITLE
fix/allow service to exit

### DIFF
--- a/ovos_dinkum_listener/__main__.py
+++ b/ovos_dinkum_listener/__main__.py
@@ -9,8 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from ovos_utils import wait_for_exit_signal
 from ovos_utils.log import init_service_logger
 
 from ovos_dinkum_listener.service import OVOSDinkumVoiceService, on_ready, \
@@ -24,8 +22,9 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     service = OVOSDinkumVoiceService(on_ready=ready_hook, on_error=error_hook,
                                      on_stopping=stopping_hook,
                                      watchdog=watchdog)
+    service.daemon = False
     service.start()
-    wait_for_exit_signal()
+    # wait until services exists by itself, or crashes
     service.stop()
 
 


### PR DESCRIPTION
relates to https://github.com/OpenVoiceOS/ovos-microphone-plugin-alsa/issues/7

instead of blocking waiting for ctrl+c press the service should crash loudly on error