### PR TITLE
Refactor minimum recording length handling

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -14,7 +14,7 @@ import json
 import subprocess
 import time
 import wave
-from threading import Timer, Event
+
 from distutils.spawn import find_executable
 from enum import Enum
 from hashlib import md5
@@ -24,7 +24,7 @@ from threading import Thread, RLock, Event
 
 import speech_recognition as sr
 from ovos_bus_client import MessageBusClient
-from ovos_bus_client.message import Message, dig_for_message
+from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
 from ovos_config import Configuration
 from ovos_config.locations import get_xdg_data_save_path
@@ -624,7 +624,9 @@ class OVOSDinkumVoiceService(Thread):
                 if not listener.get("instant_listen"):
                     self.voice_loop.state = ListeningState.CONFIRMATION
                     self.voice_loop.confirmation_event.clear()
-                    Timer(0.5, lambda: self.voice_loop.confirmation_event.set()).start()
+                    if not self.voice_loop.confirmation_event.wait(0.5):
+                        LOG.warning("Confirmation event timed out!")
+                        self.voice_loop.confirmation_event.set()
 
             if listen:
                 msg_type = "recognizer_loop:wakeword"
@@ -792,7 +794,9 @@ class OVOSDinkumVoiceService(Thread):
                 if not self.config["listener"].get("instant_listen"):
                     self.voice_loop.state = ListeningState.CONFIRMATION
                     self.voice_loop.confirmation_event.clear()
-                    Timer(0.5, lambda: self.voice_loop.confirmation_event.set()).start()
+                    if not self.voice_loop.confirmation_event.wait(0.5):
+                        LOG.warning("Confirmation event timed out!")
+                        self.voice_loop.confirmation_event.set()
                 else:
                     self.voice_loop.state = ListeningState.BEFORE_COMMAND
         else:

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -321,6 +321,8 @@ class OVOSDinkumVoiceService(Thread):
             while not self._stopping:
                 if not self._reload_event.wait(30):
                     raise TimeoutError("Timed out waiting for reload")
+                # Run the voice_loop until it is stopped; if the voice service
+                # isn't stopped, re-run the voice_loop any time it stops
                 self.voice_loop.run()
         except KeyboardInterrupt:
             LOG.info("Exit via CTRL+C")
@@ -773,7 +775,6 @@ class OVOSDinkumVoiceService(Thread):
         if self.voice_loop.wake_callback is not None:
             # Emit `recognizer_loop:record_begin`
             self.voice_loop.wake_callback()
-        self.voice_loop.reset_speech_timer()
         self.voice_loop.stt_audio_bytes = bytes()
         self.voice_loop.stt.stream_start()
         if self.voice_loop.fallback_stt is not None:
@@ -796,6 +797,7 @@ class OVOSDinkumVoiceService(Thread):
                     self.voice_loop.state = ListeningState.BEFORE_COMMAND
         else:
             self.voice_loop.state = ListeningState.BEFORE_COMMAND
+        self.voice_loop.reset_speech_timer()
 
     def _handle_mic_get_status(self, message: Message):
         """Query microphone mute status."""

--- a/test/unittests/test_service.py
+++ b/test/unittests/test_service.py
@@ -287,13 +287,6 @@ class TestDinkumVoiceService(unittest.TestCase):
         self.service.voice_loop.confirmation_event = Event()
 
         self.service._handle_listen(None)
-        self.assertAlmostEqual(self.service.voice_loop.speech_seconds_left,
-                               self.service.voice_loop.speech_seconds, 1)
-        self.assertAlmostEqual(self.service.voice_loop.timeout_seconds_left,
-                               self.service.voice_loop.timeout_seconds, 1)
-        self.assertAlmostEqual(
-            self.service.voice_loop.timeout_seconds_with_silence_left,
-            self.service.voice_loop.timeout_seconds_with_silence, 1)
         self.assertTrue(self.service.voice_loop.confirmation_event.is_set())
         self.service.voice_loop.reset_speech_timer.assert_called_once()
         self.service.voice_loop.reset_speech_timer.reset_mock()

--- a/test/unittests/test_service.py
+++ b/test/unittests/test_service.py
@@ -287,7 +287,14 @@ class TestDinkumVoiceService(unittest.TestCase):
         self.service.voice_loop.confirmation_event = Event()
 
         self.service._handle_listen(None)
-        self.assertEqual(self.service.voice_loop.confirmation_event.is_set(), False)
+        self.assertAlmostEqual(self.service.voice_loop.speech_seconds_left,
+                               self.service.voice_loop.speech_seconds, 1)
+        self.assertAlmostEqual(self.service.voice_loop.timeout_seconds_left,
+                               self.service.voice_loop.timeout_seconds, 1)
+        self.assertAlmostEqual(
+            self.service.voice_loop.timeout_seconds_with_silence_left,
+            self.service.voice_loop.timeout_seconds_with_silence, 1)
+        self.assertTrue(self.service.voice_loop.confirmation_event.is_set())
         self.service.voice_loop.reset_speech_timer.assert_called_once()
         self.service.voice_loop.reset_speech_timer.reset_mock()
         self.assertEqual(self.service.config["confirm_listening"], True)


### PR DESCRIPTION
Move timer reset to ensure minimum recording length is measured from the moment input is accepted

Related to #107
Related to #110
Also reported by a Neon user [on Matrix](https://matrix.to/#/!ZhEZYNzKBfpEAhtQIz:matrix.org/$MdRLj3Tv6zDfODvrVAuPapf_ILzPfC6yz70jkvWZJKQ?via=matrix.org&via=nitro.chat&via=rx.haunted.computer) that no input was accepted after WW confirmation sound was played