### PR TITLE
drop pocketsphinx

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -2,5 +2,5 @@ ovos-backend-client>=0.1.0
 ovos-microphone-plugin-alsa~=0.0.0
 ovos-stt-plugin-server~=0.0.3
 ovos-ww-plugin-precise-lite~=0.1
-ovos-ww-plugin-pocketsphinx~=0.1
+ovos-ww-plugin-vosk~=0.1
 ovos-vad-plugin-silero~=0.0.1


### PR DESCRIPTION
move to vosk plugin instead, only used for "wake up" in naptime mode, already accounted for in default mycroft.conf if pocketsphinx isnt available

pocketsphinx is unmaintained and latest version broke the plugin https://github.com/OpenVoiceOS/ovos-ww-plugin-pocketsphinx/pull/6 

this also brings support for py3.12