### PR TITLE
fix/clean_shutdown

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -14,17 +14,16 @@ import json
 import subprocess
 import time
 import wave
-from threading import Timer, Event
-from distutils.spawn import find_executable
 from enum import Enum
 from hashlib import md5
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from threading import Thread, RLock, Event
+from threading import Thread, RLock, Event, Timer
 
 import speech_recognition as sr
+from distutils.spawn import find_executable
 from ovos_bus_client import MessageBusClient
-from ovos_bus_client.message import Message, dig_for_message
+from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
 from ovos_config import Configuration
 from ovos_config.locations import get_xdg_data_save_path
@@ -482,7 +481,7 @@ class OVOSDinkumVoiceService(Thread):
         if not self.fake_barge_in or message.context.get("skill_id", "") == "dinkum-listener":
             # ignore our own messages
             return
-        if message.msg_type == "mycroft.volume.increase":            
+        if message.msg_type == "mycroft.volume.increase":
             vol = int(message.data.get("percent", .1) * 100)
             self._default_vol += vol
         elif message.msg_type == "mycroft.volume.decrease":
@@ -504,7 +503,7 @@ class OVOSDinkumVoiceService(Thread):
             LOG.info(f"fake barge-in lowering volume to: {self.fake_barge_in_volume}")
             self.bus.emit(
                 Message("mycroft.volume.set",
-                        {"percent": self.fake_barge_in_volume / 100,   # alsa plugin expects between 0-1
+                        {"percent": self.fake_barge_in_volume / 100,  # alsa plugin expects between 0-1
                          "play_sound": False},
                         {"skill_id": "dinkum-listener"})
             )
@@ -654,7 +653,7 @@ class OVOSDinkumVoiceService(Thread):
             LOG.info(f"fake barge-in restoring volume to: {self._default_vol}")
             self.bus.emit(
                 Message("mycroft.volume.set",
-                        {"percent": self._default_vol / 100,   # alsa plugin expects between 0-1
+                        {"percent": self._default_vol / 100,  # alsa plugin expects between 0-1
                          "play_sound": False},
                         {"skill_id": "dinkum-listener"})
             )

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -200,6 +200,8 @@ class DinkumVoiceLoop(VoiceLoop):
         while self._is_running:
             # If no audio is provided, raise an exception and stop the loop
             chunk = self.mic.read_chunk()
+            if not self._is_running:  # handle shutdown in middle of read_chunk
+                break
             assert chunk is not None, "No audio from microphone"
 
             if self.is_muted:


### PR DESCRIPTION
avoid error log spam during shutdown of service

this assertion usually fails during the shutdown process ` assert chunk is not None, "No audio from microphone"`

dinkum
```
2024-06-06 16:40:06.077 - voice - ovos_dinkum_listener.service:run:326 - INFO - Exit via CTRL+C
2024-06-06 16:40:06.078 - voice - ovos_dinkum_listener.service:run:331 - INFO - Service stopping
2024-06-06 16:40:06.078 - voice - ovos_dinkum_listener.service:on_stopping:98 - INFO - DinkumVoiceService is shutting down...
2024-06-06 16:40:06.154 - voice - ovos_dinkum_listener.service:run:333 - DEBUG - shutdown done
2024-06-06 16:40:06.155 - voice - ovos_dinkum_listener.service:run:334 - DEBUG - stopped
```

hivemind voice sat
```
2024-06-06 16:36:12.775 - HiveMind-voice-sat - hivemind_voice_satellite.service:on_stopping:20 - INFO - HiveMind Voice Satellite is shutting down...
2024-06-06 16:36:12.808 - HiveMind-voice-sat - ovos_dinkum_listener.voice_loop.voice_loop:run:272 - INFO - Loop stopped running
2024-06-06 16:36:12.808 - HiveMind-voice-sat - ovos_dinkum_listener.service:run:332 - INFO - Service stopping
2024-06-06 16:36:12.808 - HiveMind-voice-sat - hivemind_voice_satellite.service:on_stopping:20 - INFO - HiveMind Voice Satellite is shutting down...
2024-06-06 16:36:12.841 - HiveMind-voice-sat - ovos_audio.service:on_stopping:50 - INFO - TTS service is shutting down...
2024-06-06 16:36:14.574 - HiveMind-voice-sat - ovos_audio.audio:shutdown:546 - INFO - shutting down OCP
2024-06-06 16:36:14.576 - HiveMind-voice-sat - ovos_audio.audio:shutdown:546 - INFO - shutting down simple
2024-06-06 16:36:14.577 - HiveMind-voice-sat - ovos_audio_plugin_simple:stop:234 - INFO - SimpleService Stop
2024-06-06 16:36:14.578 - HiveMind-voice-sat - ovos_audio.audio:shutdown:546 - INFO - shutting down vlc
2024-06-06 16:36:14.579 - HiveMind-voice-sat - ovos_plugin_vlc:stop:93 - INFO - VLCService Stop
```