### PR TITLE
feat/alternative_transcripts

### DIFF
--- a/ovos_dinkum_listener/plugins.py
+++ b/ovos_dinkum_listener/plugins.py
@@ -60,8 +60,6 @@ class FakeStreamingSTT(StreamingSTT):
                    lang: Optional[str] = None) -> List[Tuple[str, float]]:
         """transcribe audio data to a list of
         possible transcriptions and respective confidences"""
-        if audio is None and not self.stream.buffer:
-            return []
         # plugins expect AudioData objects
         audiod = AudioData(audio or self.stream.buffer.read(),
                            sample_rate=self.stream.sample_rate,

--- a/ovos_dinkum_listener/plugins.py
+++ b/ovos_dinkum_listener/plugins.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List, Tuple
+
+from ovos_config.config import Configuration
 from ovos_plugin_manager.stt import OVOSSTTFactory
 from ovos_plugin_manager.templates.stt import StreamingSTT, StreamThread
 from ovos_plugin_manager.utils import ReadWriteStream
-from ovos_config.config import Configuration
 from ovos_utils.log import LOG
 from speech_recognition import AudioData
 
@@ -18,11 +19,11 @@ class FakeStreamThread(StreamThread):
 
     def finalize(self):
         """ return final transcription """
-        
-        if not self.buffer: 
+
+        if not self.buffer:
             return ""
 
-        try:            
+        try:
             # plugins expect AudioData objects
             audio = AudioData(self.buffer.read(),
                               sample_rate=self.sample_rate,
@@ -54,6 +55,21 @@ class FakeStreamingSTT(StreamingSTT):
         sample_width = listener.get("sample_width", 2)
         return FakeStreamThread(self.queue, self.lang, self.engine, sample_rate,
                                 sample_width)
+
+    def transcribe(self, audio: Optional = None,
+                   lang: Optional[str] = None) -> List[Tuple[str, float]]:
+        """transcribe audio data to a list of
+        possible transcriptions and respective confidences"""
+        if audio is None and not self.stream.buffer:
+            return []
+        # plugins expect AudioData objects
+        audiod = AudioData(audio or self.stream.buffer.read(),
+                           sample_rate=self.stream.sample_rate,
+                           sample_width=self.stream.sample_width)
+        transcripts = self.engine.transcribe(audiod, lang)
+        if audio is None:
+            self.stream.buffer.clear()
+        return transcripts
 
 
 def load_stt_module(config: Dict[str, Any] = None) -> StreamingSTT:

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -284,7 +284,8 @@ class OVOSDinkumVoiceService(Thread):
                 stt_audio_callback=self._stt_audio,
                 recording_audio_callback=self._recording_audio,
                 wakeup_callback=self._wakeup,
-                record_end_callback=self._record_end_signal
+                record_end_callback=self._record_end_signal,
+                min_stt_confidence=listener_config.get("min_stt_confidence", 0.6)
             )
         return loop
 

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -894,11 +894,14 @@ class OVOSDinkumVoiceService(Thread):
         audio = bytes2audiodata(wav_data)
 
         utterances = self.voice_loop.stt.transcribe(audio, lang)
+        filtered = [u for u in utterances if u[1] >= self.voice_loop.min_stt_confidence]
+        if filtered != utterances:
+            LOG.info(f"Ignoring low confidence STT transcriptions: {[u for u in utterances if u not in filtered]}")
 
-        if utterances:
+        if filtered:
             self.bus.emit(message.forward(
                 "recognizer_loop:utterance",
-                {"utterances": [u[0] for u in utterances],
+                {"utterances": [u[0] for u in filtered],
                  "lang": lang}))
         else:
             self.bus.emit(message.forward(

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -262,19 +262,15 @@ class OVOSDinkumVoiceService(Thread):
                 fallback_stt=self.fallback_stt,
                 vad=self.vad,
                 transformers=self.transformers,
-                instant_listen=listener_config.get("instant_listen"),
+                instant_listen=listener_config.get("instant_listen", True),
                 speech_seconds=listener_config.get("speech_begin", 0.3),
                 silence_seconds=listener_config.get("silence_end", 0.7),
                 timeout_seconds=listener_config.get("recording_timeout", 10),
                 timeout_seconds_with_silence=listener_config.get("recording_timeout_with_silence", 5),
                 recording_mode_max_silence_seconds=listener_config.get("recording_mode_max_silence_seconds", 30),
-                num_stt_rewind_chunks=listener_config.get(
-                    "utterance_chunks_to_rewind", 2),
-                num_hotword_keep_chunks=listener_config.get(
-                    "wakeword_chunks_to_save", 15),
-                remove_silence=listener_config.get(
-                    "remove_silence", False),
-                #
+                num_stt_rewind_chunks=listener_config.get("utterance_chunks_to_rewind", 2),
+                num_hotword_keep_chunks=listener_config.get("wakeword_chunks_to_save", 15),
+                remove_silence=listener_config.get("remove_silence", False),
                 wake_callback=self._record_begin,
                 text_callback=self._stt_text,
                 listenword_audio_callback=self._hotword_audio,
@@ -285,7 +281,8 @@ class OVOSDinkumVoiceService(Thread):
                 recording_audio_callback=self._recording_audio,
                 wakeup_callback=self._wakeup,
                 record_end_callback=self._record_end_signal,
-                min_stt_confidence=listener_config.get("min_stt_confidence", 0.6)
+                min_stt_confidence=listener_config.get("min_stt_confidence", 0.6),
+                max_transcripts=listener_config.get("max_transcripts", 1)
             )
         return loop
 

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -118,6 +118,7 @@ class DinkumVoiceLoop(VoiceLoop):
     stt_chunks: Deque = field(default_factory=deque)
     stt_audio_bytes: bytes = bytes()
     min_stt_confidence: float = 0.6
+    max_transcripts: int = 1
     last_ww: float = -1.0
     speech_seconds_left: float = 0.0
     silence_seconds_left: float = 0.0
@@ -723,6 +724,10 @@ class DinkumVoiceLoop(VoiceLoop):
         filtered = [u for u in utts if u[1] >= self.min_stt_confidence]
         if filtered != utts:
             LOG.info(f"Ignoring low confidence STT transcriptions: {[u for u in utts if u not in filtered]}")
+
+        if len(filtered) > self.max_transcripts:
+            LOG.debug(f"selecting top {self.max_transcripts} transcriptions")
+            filtered = filtered[:self.max_transcripts]
 
         stt_context["transcriptions"] = filtered
         return filtered, stt_context

--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -707,14 +707,17 @@ class DinkumVoiceLoop(VoiceLoop):
 
         # get text and trigger callback
         try:
-            utts = self.stt.transcribe() or ""
+            utts = self.stt.transcribe() or []
         except:
             LOG.exception("STT failed")
             utts = []
 
         if not utts and self.fallback_stt is not None:
             LOG.info("Attempting fallback STT plugin")
-            utts = self.fallback_stt.transcribe() or ""
+            try:
+                utts = self.fallback_stt.transcribe() or []
+            except:
+                LOG.exception("Fallback STT failed")
 
         stt_context["transcriptions"] = utts
         return utts, stt_context

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-plugin-manager<0.1.0, >=0.0.26a27
+ovos-plugin-manager<0.1.0, >=0.0.26a28
 ovos-utils>=0.0.38
 ovos-config<0.1.0, >=0.0.12
 ovos-bus-client<0.1.0, >=0.0.7


### PR DESCRIPTION
```
INFO - transcribed: [('tell me a joke', 0.97398484), ('tell Emy a joke', 0.97398484), ('tell Emmy a joke', 0.97398484), ('tell Emme a joke', 0.97398484), ('tell emmi a joke', 0.97398484)]
```

closes https://github.com/OpenVoiceOS/ovos-plugin-manager/issues/46

needs https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/236

can be tested with https://github.com/OpenVoiceOS/ovos-stt-plugin-chromium/pull/7 and https://github.com/OVOSHatchery/ovos-stt-plugin-deepgram

transcripts will be filtered by min confidence
```javascript
"listener": {"min_stt_confidence": 0.6, "max_transcripts": 3}
```

this will avoid situations such as 
```
INFO - transcribed: [('hello world', 0.7137006100000001), ('LOL', 0.55779214), ('Lowell', 0.55779214), ('lul', 0.55779214), ('loll', 0.55779214)]
```