### PR TITLE
fix/ensure_1_transcript_min

### DIFF
--- a/ovos_dinkum_listener/voice_loop/voice_loop.py
+++ b/ovos_dinkum_listener/voice_loop/voice_loop.py
@@ -721,7 +721,16 @@ class DinkumVoiceLoop(VoiceLoop):
             except:
                 LOG.exception("Fallback STT failed")
 
+        if not utts:
+            LOG.warning("STT transcription failed!")
+            return [], stt_context
+
         filtered = [u for u in utts if u[1] >= self.min_stt_confidence]
+        if not filtered:
+            # ensure min 1 transcript
+            filtered = [max(utts, key=lambda k: k[1])]
+            LOG.warning("STT transcription below minimum confidence level!!!")
+
         if filtered != utts:
             LOG.info(f"Ignoring low confidence STT transcriptions: {[u for u in utts if u not in filtered]}")
 


### PR DESCRIPTION
dont discard ALL low confidence STT, ensure at least 1 transcript is always kept

reported in chat

> Jul 01 18:40:10 mark1 hivemind-voice-sat[7176]: 2024-07-01 18:40:10.183 - HiveMind-voice-sat - ovos_dinkum_listener.voice_loop.voice_loop:_get_tx:726 - INFO - Ignoring low confidence STT transcriptions: [("what's a Kia Sportage", 0.41682079), ('whats a Kia Sportage', 0.41682079), ('wha a Kia Sportage', 0.41682079), ('whatis a Kia Sportage', 0.41682079), ("what's the Kia Sportage", 0.37308711)]
