### PR TITLE
Add xdoctest

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,4 +54,4 @@ jobs:
           pip install -r requirements/tests.txt
       - name: Run unittests
         run: |
-          pytest test/unittests
+          pytest --cov-config pyproject.toml --cov-report html --cov-report term --durations 5 --cov=ovos_dinkum_listener

--- a/ovos_dinkum_listener/voice_loop/hotwords.py
+++ b/ovos_dinkum_listener/voice_loop/hotwords.py
@@ -20,6 +20,13 @@ class HotWordException(RuntimeWarning):
 
 
 class CyclicAudioBuffer:
+    """
+    Example:
+        >>> from ovos_dinkum_listener.voice_loop.hotwords import *  # NOQA
+        >>> self = CyclicAudioBuffer()
+        >>> self.append(b'hello-world')
+        >>> print(len(self.get()))
+    """
     def __init__(self, duration=0.98, initial_data=None,
                  sample_rate=16000, sample_width=2):
         self.size = self.duration_to_bytes(duration, sample_rate, sample_width)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = [ "setuptools>=41.0.1",]
+build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--xdoctest --ignore-glob=setup.py"
+norecursedirs = ".git build __pycache__ docs"
+filterwarnings = [ "default", ]
+
+[tool.coverage.run]
+branch = true
+source = ["ovos_dinkum_listener"]
+
+[tool.coverage.report]
+exclude_lines = [ 
+    "pragma: no cover",
+     ".*  # pragma: no cover",
+     ".*  # nocover",
+     "def __repr__",
+     "raise AssertionError",
+     "raise NotImplementedError",
+     "if 0:",
+     "if trace is not None",
+     "verbose = .*",
+     "^ *raise",
+     "^ *pass *$",
+     "if _debug:",
+     "if __name__ == .__main__.:",
+]
+omit = [
+    "*/setup.py",
+]
+
+[tool.xdoctest]
+options = ''

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,3 @@
 pytest~=7.1
 ovos-vad-plugin-webrtcvad
+xdoctest~=1.1.5

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,5 @@
 pytest~=7.1
 ovos-vad-plugin-webrtcvad
 xdoctest~=1.1.5
+pytest-cov>=3.0.0
+coverage>=7.2.7 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 #
 import os
 import os.path
-from pathlib import Path
 
 from setuptools import setup
 


### PR DESCRIPTION
This PR tweaks some of the CI to include xdoctest as a pytest plugin and run doctests on the repo. I've also added code coverage and one simple doctest as an example. I cleaned up one unused import in setup.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a configuration file to enhance project build, testing, and coverage capabilities.
	- Introduced a docstring example for the `CyclicAudioBuffer` class to improve documentation.

- **Bug Fixes**
	- Improved logging messages for better clarity and error handling in various methods.

- **Chores**
	- Updated testing requirements with new dependencies for enhanced testing capabilities.
	- Minor formatting adjustments in requirements management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->