### PR TITLE
fix:save utterances

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -692,16 +692,14 @@ class OVOSDinkumVoiceService(Thread):
         @formatter.register('md5')
         def transcription_md5():
             # Build a hash of the transcription
+            
             try:
-                # handles legacy API
-                text = stt_meta.get('transcription')
-            except KeyError:
-                # handles new API
                 # transcriptions should be : List[Tuple[str, int]]
-                try:
-                    text = stt_meta.get('transcriptions')[0][0]
-                except IndexError:
-                    return 'null'
+                text = stt_meta.get('transcriptions')[0][0]
+            except IndexError:
+                # handles legacy API
+                return stt_meta.get('transcription') or 'null'
+                    
             return hash_sentence(text)
 
         filename = formatter.format(utterance_filename)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager>=0.3.1,<1.0.0
 ovos-utils>=0.0.38,<1.0.0
-ovos-config>=0.2.1,<1.0.0
+ovos-config>=0.4.3,<1.0.0
 ovos_bus_client>=0.0.10,<1.0.0
 SpeechRecognition~=3.9


### PR DESCRIPTION
backwards compat check wasnt quite right in https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/140

```
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]: 2024-10-19 08:04:47.463 - voice - ovos_dinkum_listener.service:_stt_audio:747 - ERROR - Error while saving STT audio
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]: Traceback (most recent call last):
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:   File "/home/goldyfruit/.venvs/ovos/lib64/python3.11/site-packages/ovos_dinkum_listener/service.py", line 742, in _stt_audio
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:     stt_context["filename"] = self._save_stt(audio_bytes, stt_context)
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:   File "/home/goldyfruit/.venvs/ovos/lib64/python3.11/site-packages/ovos_dinkum_listener/service.py", line 707, in _save_stt
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:     filename = formatter.format(utterance_filename)
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:   File "/home/goldyfruit/.venvs/ovos/lib64/python3.11/site-packages/ovos_dinkum_listener/_util.py", line 107, in format
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:     fmtkw = self._build_fmtkw(template, **kwargs)
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:   File "/home/goldyfruit/.venvs/ovos/lib64/python3.11/site-packages/ovos_dinkum_listener/_util.py", line 91, in _build_fmtkw
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:     fmtkw[key] = builder()
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:                  ^^^^^^^^^
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:   File "/home/goldyfruit/.venvs/ovos/lib64/python3.11/site-packages/ovos_dinkum_listener/service.py", line 705, in transcription_md5
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:     return hash_sentence(text)
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:            ^^^^^^^^^^^^^^^^^^^
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:   File "/home/goldyfruit/.venvs/ovos/lib64/python3.11/site-packages/ovos_plugin_manager/utils/tts_cache.py", line 20, in hash_sentence
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:     encoded_sentence = sentence.encode("utf-8", "ignore")
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]:                        ^^^^^^^^^^^^^^^
Oct 19 08:04:47 x270.home.lan ovos-dinkum-listener[152114]: AttributeError: 'NoneType' object has no attribute 'encode'

```

also needs https://github.com/OpenVoiceOS/ovos-config/pull/171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced speech-to-text functionality for improved transcription accuracy.
  - Improved handling of audio recordings and hotword detection.
  
- **Bug Fixes**
  - Refined error handling for audio saving operations to ensure proper logging.

- **Chores**
  - Updated `ovos-config` dependency version for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->