### PR TITLE
deprecate:upload of ww/stt

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -733,28 +733,11 @@ class OVOSDinkumVoiceService(Thread):
         LOG.debug(f"Wrote {wav_path}")
         return f"file://{wav_path.absolute()}"
 
-    def _upload_stt(self, wav_data, metadata):
-        """Upload the STT in a background thread."""
-
-        upload_url = Configuration().get("listener", {}).get('stt_upload', {}).get('url')
-
-        def upload(wav_data, metadata):
-            DatasetApi().upload_stt(wav_data, metadata, upload_url=upload_url)
-
-        if DatasetApi:
-            Thread(target=upload, daemon=True,
-                   args=(wav_data, metadata)).start()
-        else:
-            LOG.debug("`pip install ovos-backend-client` to enable upload")
-
     def _stt_audio(self, audio_bytes: bytes, stt_context: dict):
         try:
             listener = self.config["listener"]
             if listener["save_utterances"]:
                 stt_context["filename"] = self._save_stt(audio_bytes, stt_context)
-                upload_disabled = listener.get('stt_upload', {}).get('disable')
-                if self.config['opt_in'] and not upload_disabled:
-                    self._upload_stt(audio_bytes, stt_context)
         except Exception:
             LOG.exception("Error while saving STT audio")
         return stt_context

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -47,11 +47,6 @@ from ovos_dinkum_listener.transformers import AudioTransformersService
 from ovos_dinkum_listener.voice_loop import DinkumVoiceLoop, ListeningMode, ListeningState
 from ovos_dinkum_listener.voice_loop.hotwords import HotwordContainer
 
-try:
-    from ovos_backend_client.api import DatasetApi
-except ImportError:
-    LOG.info("`ovos-backend-client` is not installed. Upload is disabled")
-    DatasetApi = None
 
 try:
     from ovos_utils.sound import get_sound_duration
@@ -565,22 +560,6 @@ class OVOSDinkumVoiceService(Thread):
         LOG.debug(f"Wrote {wav_path}")
         return f"file://{wav_path.absolute()}"
 
-    def _upload_hotword(self, wav_data, metadata):
-        """Upload the wakeword in a background thread."""
-
-        upload_url = Configuration().get("listener", {}).get('wake_word_upload', {}).get('url')
-
-        def upload(wav_data, metadata):
-            DatasetApi().upload_wake_word(wav_data,
-                                          metadata,
-                                          upload_url=upload_url)
-
-        if DatasetApi is not None:
-            Thread(target=upload, daemon=True,
-                   args=(wav_data, metadata)).start()
-        else:
-            LOG.debug("`pip install ovos-backend-client` to enable upload")
-
     @staticmethod
     def _compile_ww_context(key_phrase, ww_module):
         """ creates metadata in the format expected by selene
@@ -614,11 +593,6 @@ class OVOSDinkumVoiceService(Thread):
             listener = self.config["listener"]
             if listener["record_wake_words"]:
                 payload["filename"] = self._save_ww(audio_bytes, ww_context)
-
-            upload_disabled = listener.get('wake_word_upload',
-                                           {}).get('disable')
-            if self.config['opt_in'] and not upload_disabled:
-                self._upload_hotword(audio_bytes, ww_context)
 
             utterance = ww_context.get("utterance")
             if utterance:


### PR DESCRIPTION
if desired wake-word/STT upload can be added back via a audio transformer plugin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified audio handling logic for hotword detection, focusing on local processing without backend uploads.

- **Bug Fixes**
	- Removed redundant error handling related to hotword audio uploads, enhancing overall service stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->