### PR TITLE
fix: python 3.13 support

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Build Tools
         run: |
-          python -m pip install build wheel
+          python -m pip install build wheel setuptools
       - name: Install System Dependencies
         run: |
           sudo apt-get update

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,3 +3,4 @@ ovos-utils>=0.8.1,<1.0.0
 ovos-config>=1.2.2,<3.0.0
 ovos_bus_client>=1.3.4,<2.0.0
 SpeechRecognition~=3.9
+audioop-lts; python_version>='3.13'  # removed from stdlib in py 3.13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended continuous integration pipeline to test against Python 3.12 and 3.13.
  * Updated build process configuration with setuptools alongside existing build tools.
  * Added new runtime dependency for enhanced Python 3.13 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->