### PR TITLE
refactor: drop speech_recognition

### DIFF
--- a/ovos_dinkum_listener/plugins.py
+++ b/ovos_dinkum_listener/plugins.py
@@ -4,8 +4,8 @@ from ovos_config.config import Configuration
 from ovos_plugin_manager.stt import OVOSSTTFactory
 from ovos_plugin_manager.templates.stt import StreamingSTT, StreamThread
 from ovos_plugin_manager.utils import ReadWriteStream
+from ovos_plugin_manager.utils.audio import AudioData
 from ovos_utils.log import LOG
-from speech_recognition import AudioData
 
 
 class FakeStreamThread(StreamThread):

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -23,7 +23,6 @@ from tempfile import NamedTemporaryFile
 from threading import Thread, RLock, Event
 from typing import List, Tuple, Optional, Union
 
-import speech_recognition as sr
 import time
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.message import Message
@@ -35,11 +34,13 @@ from ovos_plugin_manager.stt import get_stt_lang_configs, get_stt_supported_lang
 from ovos_plugin_manager.templates.microphone import Microphone
 from ovos_plugin_manager.templates.stt import STT, StreamingSTT
 from ovos_plugin_manager.templates.vad import VADEngine
+from ovos_plugin_manager.utils.audio import AudioData, AudioFile
 from ovos_plugin_manager.utils.tts_cache import hash_sentence
 from ovos_plugin_manager.vad import OVOSVADFactory, get_vad_configs
 from ovos_plugin_manager.wakewords import get_ww_lang_configs, get_ww_supported_langs, get_ww_module_configs
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG, log_deprecation
+from ovos_utils.sound import get_sound_duration
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap, ProcessState
 
 import warnings
@@ -50,19 +51,12 @@ from ovos_dinkum_listener.voice_loop import DinkumVoiceLoop, ListeningMode, List
 from ovos_dinkum_listener.voice_loop.hotwords import HotwordContainer
 
 
-try:
-    from ovos_utils.sound import get_sound_duration
-except ImportError:
-
-    def get_sound_duration(*args, **kwargs):
-        raise ImportError("please install ovos-utils>=0.1.0a25")
 
 # Seconds between systemd watchdog updates
 WATCHDOG_DELAY = 0.5
 
 
 def bytes2audiodata(data):
-    recognizer = sr.Recognizer()
     with NamedTemporaryFile() as fp:
         fp.write(data)
         ffmpeg = which("ffmpeg")
@@ -76,8 +70,8 @@ def bytes2audiodata(data):
             LOG.warning("ffmpeg not found, please ensure audio is in a valid format")
             p = fp.name
 
-        with sr.AudioFile(p) as source:
-            audio = recognizer.record(source)
+        with AudioFile(p) as source:
+            audio = source.read()
     return audio
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
-ovos-plugin-manager>=1.0.2,<3.0.0
-ovos-utils>=0.8.1,<1.0.0
+ovos-plugin-manager>=2.1.1,<3.0.0
+ovos-utils>=0.8.4,<1.0.0
 ovos-config>=1.2.2,<3.0.0
 ovos_bus_client>=1.3.4,<2.0.0
-SpeechRecognition~=3.9
 audioop-lts; python_version>='3.13'  # removed from stdlib in py 3.13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated ovos-plugin-manager minimum requirement from 1.0.2 to 2.1.1.
  * Updated ovos-utils minimum requirement from 0.8.1 to 0.8.4.
  * Removed SpeechRecognition as an external dependency.
  * Added audioop-lts package for Python 3.13+ compatibility.

* **Refactor**
  * Enhanced internal audio processing implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->