### PR TITLE
feat: gate utterance entry topic by legacy_namespace (AUDIO-IN-1 §5)

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -625,7 +625,11 @@ class OVOSDinkumVoiceService(Thread):
                     "utterances": [utterance],
                     "lang": stt_lang or Configuration().get("lang", "en-us"),
                 }
-                self.bus.emit(Message("recognizer_loop:utterance", payload, context))
+                # OVOS-AUDIO-IN-1 §5 utterance entry: legacy recognizer_loop:utterance
+                # or spec ovos.utterance.handle, per the 'legacy_namespace' config.
+                topic = "recognizer_loop:utterance" \
+                    if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
+                self.bus.emit(Message(topic, payload, context))
                 return payload
 
             # If enabled, play a wave file with a short sound to audibly
@@ -718,7 +722,10 @@ class OVOSDinkumVoiceService(Thread):
         if utts:
             lang = stt_context.get("lang") or Configuration().get("lang", "en-us")
             payload = {"utterances": utts, "lang": lang}
-            self.bus.emit(Message("recognizer_loop:utterance", payload, stt_context))
+            # OVOS-AUDIO-IN-1 §5 utterance entry: legacy or spec namespace.
+            topic = "recognizer_loop:utterance" \
+                if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
+            self.bus.emit(Message(topic, payload, stt_context))
         else:
             if self.voice_loop.listen_mode != ListeningMode.CONTINUOUS:
                 LOG.error("Empty transcription, either recorded silence or STT failed!")
@@ -1016,12 +1023,11 @@ class OVOSDinkumVoiceService(Thread):
             LOG.info(f"Ignoring low confidence STT transcriptions: {ignored}")
 
         if filtered:
-            self.bus.emit(
-                message.forward(
-                    "recognizer_loop:utterance",
-                    {"utterances": [u[0] for u in filtered], "lang": lang},
-                )
-            )
+            payload = {"utterances": [u[0] for u in filtered], "lang": lang}
+            # OVOS-AUDIO-IN-1 §5 utterance entry: legacy or spec namespace.
+            topic = "recognizer_loop:utterance" \
+                if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
+            self.bus.emit(message.forward(topic, payload))
         else:
             self.bus.emit(message.forward("recognizer_loop:speech.recognition.unknown"))
 

--- a/test/unittests/test_spec_bus_messages.py
+++ b/test/unittests/test_spec_bus_messages.py
@@ -1,0 +1,74 @@
+"""Namespace bus-message tests.
+
+The utterance entry topic is emitted in exactly one namespace, chosen by the
+``legacy_namespace`` config (default True): the legacy
+``recognizer_loop:utterance`` or the OVOS-AUDIO-IN-1 §5 ``ovos.utterance.handle``.
+Both modes are covered here.
+"""
+import shutil
+import unittest
+from os import environ, makedirs
+from os.path import join, dirname
+from unittest.mock import Mock, MagicMock, patch
+
+from ovos_config.config import Configuration
+from ovos_utils.messagebus import FakeBus
+
+
+class TestUtteranceEntryNamespace(unittest.TestCase):
+
+    config_dir = join(dirname(__file__), "config_spec")
+
+    @classmethod
+    def setUpClass(cls):
+        environ["XDG_CONFIG_HOME"] = cls.config_dir
+        makedirs(cls.config_dir, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        environ.pop("XDG_CONFIG_HOME", None)
+        shutil.rmtree(cls.config_dir, ignore_errors=True)
+
+    @patch("ovos_dinkum_listener.service.OVOSMicrophoneFactory.create")
+    @patch("ovos_dinkum_listener.service.OVOSVADFactory.create")
+    @patch("ovos_dinkum_listener.voice_loop.DinkumVoiceLoop")
+    @patch("ovos_dinkum_listener.plugins.load_fallback_stt")
+    @patch("ovos_dinkum_listener.plugins.load_stt_module")
+    def _make_service(self, load_stt, load_fallback, voice_loop, vad, mic_factory):
+        from ovos_dinkum_listener.service import OVOSDinkumVoiceService
+        from ovos_plugin_manager.templates.vad import VADEngine
+        load_stt.return_value = Mock(shutdown=Mock())
+        load_fallback.return_value = Mock(shutdown=Mock())
+        vad.return_value = MagicMock(spec=VADEngine)
+        return OVOSDinkumVoiceService(mic=Mock(stop=Mock()), bus=self.bus)
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.bus.started_running = True
+        self.service = self._make_service()
+        self.seen = {}
+        for topic in ("recognizer_loop:utterance", "ovos.utterance.handle"):
+            self.bus.on(topic, lambda m: self.seen.__setitem__(m.msg_type, m))
+
+    def tearDown(self):
+        Configuration()["legacy_namespace"] = True
+
+    def test_legacy_namespace_emits_only_legacy_topic(self):
+        Configuration()["legacy_namespace"] = True
+        self.service._stt_text([("hello world", 0.9)], {"lang": "en-US"})
+        self.assertIn("recognizer_loop:utterance", self.seen)
+        self.assertNotIn("ovos.utterance.handle", self.seen)
+        self.assertEqual(self.seen["recognizer_loop:utterance"].data["utterances"],
+                         ["hello world"])
+
+    def test_spec_namespace_emits_only_spec_topic(self):
+        Configuration()["legacy_namespace"] = False
+        self.service._stt_text([("hello world", 0.9)], {"lang": "en-US"})
+        self.assertIn("ovos.utterance.handle", self.seen)
+        self.assertNotIn("recognizer_loop:utterance", self.seen)
+        self.assertEqual(self.seen["ovos.utterance.handle"].data["utterances"],
+                         ["hello world"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_spec_bus_messages.py
+++ b/test/unittests/test_spec_bus_messages.py
@@ -49,9 +49,10 @@ class TestUtteranceEntryNamespace(unittest.TestCase):
         self.seen = {}
         for topic in ("recognizer_loop:utterance", "ovos.utterance.handle"):
             self.bus.on(topic, lambda m: self.seen.__setitem__(m.msg_type, m))
+        self._orig_legacy_ns = Configuration().get("legacy_namespace", True)
 
     def tearDown(self):
-        Configuration()["legacy_namespace"] = True
+        Configuration()["legacy_namespace"] = self._orig_legacy_ns
 
     def test_legacy_namespace_emits_only_legacy_topic(self):
         Configuration()["legacy_namespace"] = True


### PR DESCRIPTION
All three utterance emit sites (hotword, STT text, b64 audio) emit either the legacy `recognizer_loop:utterance` or the spec `ovos.utterance.handle` (OVOS-AUDIO-IN-1 §5), chosen by the deployment `legacy_namespace` config (default `True`) — never both. Part of the org-wide bus-namespace transition. Dual-namespace tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)