### PR TITLE
feat: dual-emit utterance entry during namespace migration

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -24,7 +24,6 @@ import time
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
-from ovos_bus_client.util.migration import emit_migration_pair
 from ovos_config import Configuration
 from ovos_config.locations import get_xdg_data_save_path
 from ovos_plugin_manager.microphone import OVOSMicrophoneFactory
@@ -679,11 +678,8 @@ class OVOSDinkumVoiceService(Thread):
                 # gates the legacy emit; drop the dual-emit next major.
                 msg = Message("", payload, context)
                 if Configuration().get("legacy_namespace", True):
-                    emit_migration_pair(self.bus, msg,
-                                        "recognizer_loop:utterance",
-                                        "ovos.utterance.handle", payload)
-                else:
-                    self.bus.emit(msg.forward("ovos.utterance.handle", payload))
+                    self.bus.emit(msg.forward("recognizer_loop:utterance", payload))
+                self.bus.emit(msg.forward("ovos.utterance.handle", payload))
                 return payload
 
             # If enabled, play a wave file with a short sound to audibly
@@ -781,11 +777,8 @@ class OVOSDinkumVoiceService(Thread):
             # legacy_namespace gates the legacy emit; drop dual-emit next major.
             msg = Message("", payload, stt_context)
             if Configuration().get("legacy_namespace", True):
-                emit_migration_pair(self.bus, msg,
-                                    "recognizer_loop:utterance",
-                                    "ovos.utterance.handle", payload)
-            else:
-                self.bus.emit(msg.forward("ovos.utterance.handle", payload))
+                self.bus.emit(msg.forward("recognizer_loop:utterance", payload))
+            self.bus.emit(msg.forward("ovos.utterance.handle", payload))
         else:
             if self.voice_loop.listen_mode != ListeningMode.CONTINUOUS:
                 LOG.error("Empty transcription, either recorded silence or STT failed!")
@@ -1104,11 +1097,8 @@ class OVOSDinkumVoiceService(Thread):
             # namespace during the migration; consumers dedup on content.
             # legacy_namespace gates the legacy emit; drop dual-emit next major.
             if Configuration().get("legacy_namespace", True):
-                emit_migration_pair(self.bus, message,
-                                    "recognizer_loop:utterance",
-                                    "ovos.utterance.handle", payload)
-            else:
-                self.bus.emit(message.forward("ovos.utterance.handle", payload))
+                self.bus.emit(message.forward("recognizer_loop:utterance", payload))
+            self.bus.emit(message.forward("ovos.utterance.handle", payload))
         else:
             self.bus.emit(message.forward("recognizer_loop:speech.recognition.unknown"))
 

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -24,6 +24,7 @@ import time
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
+from ovos_bus_client.util.migration import emit_migration_pair
 from ovos_config import Configuration
 from ovos_config.locations import get_xdg_data_save_path
 from ovos_plugin_manager.microphone import OVOSMicrophoneFactory
@@ -671,11 +672,18 @@ class OVOSDinkumVoiceService(Thread):
                     "utterances": [utterance],
                     "lang": stt_lang or Configuration().get("lang", "en-us"),
                 }
-                # OVOS-AUDIO-IN-1 §5 utterance entry: legacy recognizer_loop:utterance
-                # or spec ovos.utterance.handle, per the 'legacy_namespace' config.
-                topic = "recognizer_loop:utterance" \
-                    if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
-                self.bus.emit(Message(topic, payload, context))
+                # OVOS-AUDIO-IN-1 §5 utterance entry. During the namespace
+                # migration dual-emit on the legacy recognizer_loop:utterance
+                # and the new ovos.utterance.handle so nodes on either version
+                # interoperate; consumers dedup on content. legacy_namespace
+                # gates the legacy emit; drop the dual-emit next major.
+                msg = Message("", payload, context)
+                if Configuration().get("legacy_namespace", True):
+                    emit_migration_pair(self.bus, msg,
+                                        "recognizer_loop:utterance",
+                                        "ovos.utterance.handle", payload)
+                else:
+                    self.bus.emit(msg.forward("ovos.utterance.handle", payload))
                 return payload
 
             # If enabled, play a wave file with a short sound to audibly
@@ -768,10 +776,16 @@ class OVOSDinkumVoiceService(Thread):
         if utts:
             lang = stt_context.get("lang") or Configuration().get("lang", "en-us")
             payload = {"utterances": utts, "lang": lang}
-            # OVOS-AUDIO-IN-1 §5 utterance entry: legacy or spec namespace.
-            topic = "recognizer_loop:utterance" \
-                if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
-            self.bus.emit(Message(topic, payload, stt_context))
+            # OVOS-AUDIO-IN-1 §5 utterance entry. Dual-emit on legacy and new
+            # namespace during the migration; consumers dedup on content.
+            # legacy_namespace gates the legacy emit; drop dual-emit next major.
+            msg = Message("", payload, stt_context)
+            if Configuration().get("legacy_namespace", True):
+                emit_migration_pair(self.bus, msg,
+                                    "recognizer_loop:utterance",
+                                    "ovos.utterance.handle", payload)
+            else:
+                self.bus.emit(msg.forward("ovos.utterance.handle", payload))
         else:
             if self.voice_loop.listen_mode != ListeningMode.CONTINUOUS:
                 LOG.error("Empty transcription, either recorded silence or STT failed!")
@@ -1086,10 +1100,15 @@ class OVOSDinkumVoiceService(Thread):
 
         if filtered:
             payload = {"utterances": [u[0] for u in filtered], "lang": lang}
-            # OVOS-AUDIO-IN-1 §5 utterance entry: legacy or spec namespace.
-            topic = "recognizer_loop:utterance" \
-                if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
-            self.bus.emit(message.forward(topic, payload))
+            # OVOS-AUDIO-IN-1 §5 utterance entry. Dual-emit on legacy and new
+            # namespace during the migration; consumers dedup on content.
+            # legacy_namespace gates the legacy emit; drop dual-emit next major.
+            if Configuration().get("legacy_namespace", True):
+                emit_migration_pair(self.bus, message,
+                                    "recognizer_loop:utterance",
+                                    "ovos.utterance.handle", payload)
+            else:
+                self.bus.emit(message.forward("ovos.utterance.handle", payload))
         else:
             self.bus.emit(message.forward("recognizer_loop:speech.recognition.unknown"))
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager>=2.1.1,<3.0.0
 ovos-utils>=0.8.4,<1.0.0
 ovos-config>=1.2.2,<3.0.0
-ovos_bus_client>=1.3.4,<3.0.0
+ovos_bus_client>=2.2.0a1,<3.0.0
 audioop-lts; python_version>='3.13'  # removed from stdlib in py 3.13

--- a/test/unittests/test_spec_bus_messages.py
+++ b/test/unittests/test_spec_bus_messages.py
@@ -1,9 +1,10 @@
 """Namespace bus-message tests.
 
-The utterance entry topic is emitted in exactly one namespace, chosen by the
-``legacy_namespace`` config (default True): the legacy
-``recognizer_loop:utterance`` or the OVOS-AUDIO-IN-1 §5 ``ovos.utterance.handle``.
-Both modes are covered here.
+During the namespace migration the utterance entry is dual-emitted on BOTH the
+legacy ``recognizer_loop:utterance`` and the OVOS-AUDIO-IN-1 §5
+``ovos.utterance.handle`` topics so nodes on either version interoperate;
+consumers dedup on content. When ``legacy_namespace`` is False only the new
+topic is emitted. Both modes are covered here.
 """
 import shutil
 import unittest
@@ -31,9 +32,9 @@ class TestUtteranceEntryNamespace(unittest.TestCase):
 
     @patch("ovos_dinkum_listener.service.OVOSMicrophoneFactory.create")
     @patch("ovos_dinkum_listener.service.OVOSVADFactory.create")
-    @patch("ovos_dinkum_listener.voice_loop.DinkumVoiceLoop")
-    @patch("ovos_dinkum_listener.plugins.load_fallback_stt")
-    @patch("ovos_dinkum_listener.plugins.load_stt_module")
+    @patch("ovos_dinkum_listener.service.DinkumVoiceLoop")
+    @patch("ovos_dinkum_listener.service.load_fallback_stt")
+    @patch("ovos_dinkum_listener.service.load_stt_module")
     def _make_service(self, load_stt, load_fallback, voice_loop, vad, mic_factory):
         from ovos_dinkum_listener.service import OVOSDinkumVoiceService
         from ovos_plugin_manager.templates.vad import VADEngine
@@ -46,28 +47,32 @@ class TestUtteranceEntryNamespace(unittest.TestCase):
         self.bus = FakeBus()
         self.bus.started_running = True
         self.service = self._make_service()
-        self.seen = {}
-        for topic in ("recognizer_loop:utterance", "ovos.utterance.handle"):
-            self.bus.on(topic, lambda m: self.seen.__setitem__(m.msg_type, m))
+        self.seen = {"recognizer_loop:utterance": [],
+                     "ovos.utterance.handle": []}
+        for topic in self.seen:
+            self.bus.on(topic, lambda m: self.seen[m.msg_type].append(m))
         self._orig_legacy_ns = Configuration().get("legacy_namespace", True)
 
     def tearDown(self):
         Configuration()["legacy_namespace"] = self._orig_legacy_ns
 
-    def test_legacy_namespace_emits_only_legacy_topic(self):
+    def test_legacy_namespace_dual_emits_both_topics(self):
         Configuration()["legacy_namespace"] = True
         self.service._stt_text([("hello world", 0.9)], {"lang": "en-US"})
-        self.assertIn("recognizer_loop:utterance", self.seen)
-        self.assertNotIn("ovos.utterance.handle", self.seen)
-        self.assertEqual(self.seen["recognizer_loop:utterance"].data["utterances"],
-                         ["hello world"])
+        self.assertEqual(len(self.seen["recognizer_loop:utterance"]), 1)
+        self.assertEqual(len(self.seen["ovos.utterance.handle"]), 1)
+        # both carry the same payload
+        for topic in self.seen:
+            self.assertEqual(self.seen[topic][0].data["utterances"],
+                             ["hello world"])
+            self.assertEqual(self.seen[topic][0].data["lang"], "en-US")
 
     def test_spec_namespace_emits_only_spec_topic(self):
         Configuration()["legacy_namespace"] = False
         self.service._stt_text([("hello world", 0.9)], {"lang": "en-US"})
-        self.assertIn("ovos.utterance.handle", self.seen)
-        self.assertNotIn("recognizer_loop:utterance", self.seen)
-        self.assertEqual(self.seen["ovos.utterance.handle"].data["utterances"],
+        self.assertEqual(len(self.seen["ovos.utterance.handle"]), 1)
+        self.assertEqual(len(self.seen["recognizer_loop:utterance"]), 0)
+        self.assertEqual(self.seen["ovos.utterance.handle"][0].data["utterances"],
                          ["hello world"])
 
 


### PR DESCRIPTION
## What

Switches the utterance-entry emit from single-emit-gated to **dual-emit + content dedup** for the `recognizer_loop:utterance` → `ovos.utterance.handle` namespace migration (architecture PIPELINE-1 §9.1 / AUDIO-IN-1 §5).

During the migration, producers emit the utterance on **both** the legacy `recognizer_loop:utterance` and the new `ovos.utterance.handle` topics so nodes on either version interoperate (a HiveMind satellite need not upgrade in lockstep with core). Consumers (ovos-core) dedup on content via `ovos_bus_client.util.migration.TransitionalDeduplicator` so they handle each utterance once.

- Dual-emit is gated on `Configuration().get("legacy_namespace", True)`:
  - `True` (default) → dual-emit on both topics via `emit_migration_pair(...)`
  - `False` → emit only `ovos.utterance.handle`
- Migration aid; removable next major.

## Sites changed (`ovos_dinkum_listener/service.py`)
- `_hotword_audio` (hotword-as-utterance entry)
- `_stt_text` (normal STT result)
- the external-transcribe handler (`message.forward` path)
- import of `emit_migration_pair`

## Tests
`test/unittests/test_spec_bus_messages.py` rewritten to assert **both** topics are emitted when `legacy_namespace=True` and **only** the new topic when `False` (FakeBus). Passing locally.

## Stacking / CI
Depends on the new migration helpers in **ovos-bus-client#228** (`feat/namespace-migration-dedup`, unpublished). The `ovos-bus-client>=2.2.0a1` floor is unpublished, so **CI will be red until #228 merges and releases**. Stacked on ovos-bus-client#228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)