### PR TITLE
fix: order audio-transformer chain ascending per OVOS-TRANSFORM-1 §4

### DIFF
--- a/ovos_dinkum_listener/transformers.py
+++ b/ovos_dinkum_listener/transformers.py
@@ -61,15 +61,17 @@ class AudioTransformersService:
     @property
     def plugins(self) -> list:
         """
-        Return loaded transformers in priority order, such that modules with a
-        higher `priority` rank are called first and changes from lower ranked
-        transformers are applied last.
+        Return loaded transformers in ascending priority order per
+        OVOS-TRANSFORM-1 §4: a transformer with ``priority = 1`` runs before
+        one with ``priority = 50`` runs before one with ``priority = 100``.
+        Lower number = earlier in the chain.
 
-        A plugin of `priority` 1 will override any existing context keys and
-        will be the last to modify `audio_data`
+        A plugin of `priority` 1 is the first to modify `audio_data`; later
+        (higher-priority-number) transformers see and may override the context
+        keys and audio earlier transformers produced.
         """
         return sorted(
-            self.loaded_plugins.values(), key=lambda k: k.priority, reverse=True
+            self.loaded_plugins.values(), key=lambda k: k.priority
         )
 
     def shutdown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "ovos-plugin-manager>=2.5.0a1,<3.0.0",
     "ovos-utils>=0.8.4,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
-    "ovos_bus_client>=2.2.0a1,<3.0.0",
-    "ovos-spec-tools>=0.9.0a1,<1.0.0",
+    "ovos_bus_client>=2.5.1a1,<3.0.0",
+    "ovos-spec-tools>=0.16.1a2,<1.0.0",
     "audioop-lts; python_version >= '3.13'",  # removed from stdlib in py 3.13
 ]
 

--- a/test/unittests/test_transformers.py
+++ b/test/unittests/test_transformers.py
@@ -93,7 +93,56 @@ class TestTransformers(unittest.TestCase):
         service.shutdown()
         MockTransformer.shutdown.assert_called_once()
 
-    # TODO: Test priority load
+    @patch("ovos_plugin_manager.audio_transformers.find_audio_transformer_plugins")
+    def test_audio_transformer_ascending_priority_order(self, find_transformers):
+        """Per OVOS-TRANSFORM-1 §4 the chain runs in ascending priority order:
+        lower `priority` number = earlier in the chain."""
+        import ovos_dinkum_listener.transformers
+
+        ovos_dinkum_listener.transformers.find_audio_transformer_plugins = (
+            find_transformers
+        )
+        from ovos_dinkum_listener.transformers import AudioTransformersService
+
+        def _make(name, prio):
+            return type(
+                f"Mock_{name}",
+                (AudioTransformer,),
+                {
+                    "feed_audio_chunk": Mock(),
+                    "feed_hotword_chunk": Mock(),
+                    "feed_speech_chunk": Mock(),
+                    "feed_speech_utterance": Mock(return_value=b"0"),
+                    "transform": Mock(return_value=(b"1", {})),
+                    "shutdown": Mock(),
+                    "__init__": lambda self, n=name, p=prio: AudioTransformer.__init__(
+                        self, n, priority=p
+                    ),
+                },
+            )
+
+        # declare out of priority order on purpose
+        find_transformers.return_value = {
+            "late": _make("late", 90),
+            "early": _make("early", 5),
+            "mid": _make("mid", 50),
+        }
+        config = {
+            "listener": {
+                "audio_transformers": {
+                    "late": {"active": True},
+                    "early": {"active": True},
+                    "mid": {"active": True},
+                }
+            }
+        }
+        service = AudioTransformersService(self.bus, config)
+
+        ordered = [p.priority for p in service.plugins]
+        self.assertEqual(ordered, sorted(ordered))  # ascending
+        self.assertEqual(ordered, [5, 50, 90])
+        names = [p.name for p in service.plugins]
+        self.assertEqual(names, ["early", "mid", "late"])  # low prio runs first
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

The audio-transformer chain in `AudioTransformersService.plugins` sorted **descending** by priority (`reverse=True`) with a docstring claiming a `priority 1` plugin runs *last*. This is inverted from the spec.

**OVOS-AUDIO-IN-1 §4**: the audio input service *MUST run the audio-transformer chain (OVOS-TRANSFORM-1 §3.1), configured per OVOS-TRANSFORM-1 §4.*

**OVOS-TRANSFORM-1 §4**: *A chain runs in **ascending priority order**: a transformer with `priority = 1` runs before one with `priority = 50` runs before one with `priority = 100`. Lower number = earlier in the chain.* §9 makes this a MUST for any implemented chain.

This change:
- drops `reverse=True` so the chain sorts ascending (lower number = earlier);
- corrects the docstring to match the spec;
- adds a unit test asserting ascending order (`[5, 50, 90]` → `early, mid, late`).

## Back-compat

Shipped audio transformers are language/payload **producers** that should run early:

| plugin | priority |
|--------|----------|
| ovos-audio-transformer-plugin-fasterwhisper (lang detect) | 10 |
| ovos-audio-transformer-plugin-ggwave | 10 |
| ovos-audio-transformer-redis-publish | 50 (default) |

The two `priority=10` plugins are equal, so the flip never reorders them relative to each other; it only moves them ahead of default-50 transformers — the correct producer-first ordering. No shipped plugin relied on the old descending "run-last-wins" semantics. This aligns the listener with the already-fixed ovos-core transformer chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)