### PR TITLE
refactor: consume transformer runner services from ovos-plugin-manager

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -60,13 +60,15 @@ Sets `self.has_loaded = True` when done — `transformers.py:59`.
 
 ## `plugins` property — `transformers.py:62`
 
-Returns all loaded plugins sorted by **descending** priority — `transformers.py:71`:
+Returns all loaded plugins sorted by **ascending** priority (OVOS-TRANSFORM §4):
 
 ```python
-sorted(self.loaded_plugins.values(), key=lambda k: k.priority, reverse=True)
+sorted(self.loaded_plugins.values(), key=lambda k: k.priority)
 ```
 
-Higher `priority` number → called first. A plugin with `priority=1` runs last and has final say over both audio and context.
+Lower `priority` number → called first (default 50). A plugin with `priority=1` runs first; later plugins see and may override its audio and context. An explicit `"order"` list in the config section wins over priorities. The service is the canonical `AudioTransformersService` from `ovos_plugin_manager.transformer_services`; full contract → [`ovos-plugin-manager/docs/transformers.md`](../../ovos-plugin-manager/docs/transformers.md).
+
+**Split deployments:** ovos-stt-server, hivemind-audio-binary-protocol and the HiveMind satellites can run audio transformers too — enable each plugin in exactly one place or audio is processed twice.
 
 ---
 
@@ -152,7 +154,7 @@ Audio transformer plugins must implement (from the OPM base class):
 | `feed_speech_utterance(chunk)` | `transform()` | Complete utterance |
 | `transform(chunk)` → `(bytes, dict)` | `transform()` | Final transform + metadata |
 
-Attribute `priority: int` controls ordering (higher = runs first).
+Attribute `priority: int` controls ordering (lower = runs first).
 
 Entry point group: `opm.audio_transformer`
 

--- a/ovos_dinkum_listener/transformers.py
+++ b/ovos_dinkum_listener/transformers.py
@@ -26,109 +26,24 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from typing import Optional
+
 from ovos_plugin_manager.audio_transformers import find_audio_transformer_plugins
-from ovos_utils.json_helper import merge_dict
-from ovos_utils.log import LOG
+from ovos_plugin_manager.transformer_services import (
+    AudioTransformersService as _AudioTransformersService)
 
 
-class AudioTransformersService:
-    def __init__(self, bus, config=None):
-        self.config_core = config or {}
-        self.loaded_plugins = {}
-        self.has_loaded = False
-        self.bus = bus
-        # to activate a plugin, just add an entry to mycroft.conf for it
-        listener_config = self.config_core.get("listener") or {}
-        self.config = listener_config.get("audio_transformers") or {}
-        self.load_plugins()
+class AudioTransformersService(_AudioTransformersService):
+    """Transforms raw audio before the STT stage, in OVOS-TRANSFORM §4
+    ascending priority order: a plugin of priority 1 runs first."""
 
-    def load_plugins(self):
-        for plug_name, plug in find_audio_transformer_plugins().items():
-            if plug_name in self.config:
-                # if disabled skip it
-                if not self.config[plug_name].get("active", True):
-                    continue
-                try:
-                    self.loaded_plugins[plug_name] = plug()
-                    self.loaded_plugins[plug_name].bind(self.bus)
-                    LOG.info(f"loaded audio transformer plugin: {plug_name}")
-                except Exception:
-                    LOG.exception(
-                        f"Failed to load audio transformer plugin: {plug_name}"
-                    )
-        self.has_loaded = True
+    def __init__(self, bus, config: Optional[dict] = None):
+        super().__init__(bus=bus, config=config or {},
+                         default_context={
+                             "client_name": "ovos_dinkum_listener",
+                             "source": "audio",  # default native audio source
+                             "destination": ["skills"]})
 
-    @property
-    def plugins(self) -> list:
-        """
-        Return loaded transformers in ascending priority order per
-        OVOS-TRANSFORM-1 §4: a transformer with ``priority = 1`` runs before
-        one with ``priority = 50`` runs before one with ``priority = 100``.
-        Lower number = earlier in the chain.
-
-        A plugin of `priority` 1 is the first to modify `audio_data`; later
-        (higher-priority-number) transformers see and may override the context
-        keys and audio earlier transformers produced.
-        """
-        return sorted(
-            self.loaded_plugins.values(), key=lambda k: k.priority
-        )
-
-    def shutdown(self):
-        """
-        Shutdown all loaded plugins
-        """
-        for module in self.plugins:
-            try:
-                module.shutdown()
-            except Exception as e:
-                LOG.warning(e)
-
-    def feed_audio(self, chunk: bytes):
-        """
-        Feed a chunk of untagged (not speech) audio to all loaded plugins
-        @param chunk: bytes of audio data
-        """
-        for module in self.plugins:
-            module.feed_audio_chunk(chunk)
-
-    def feed_hotword(self, chunk: bytes):
-        """
-        Feed a chunk of hotword audio to all loaded plugins
-        @param chunk: bytes of audio data
-        """
-        for module in self.plugins:
-            module.feed_hotword_chunk(chunk)
-
-    def feed_speech(self, chunk: bytes):
-        """
-        Feed a chunk of speech audio to all loaded plugins
-        @param chunk: bytes of audio data
-        """
-        try:
-            for module in self.plugins:
-                module.feed_speech_chunk(chunk)
-        except Exception as e:
-            LOG.exception(e)
-
-    def transform(self, chunk: bytes) -> (bytes, dict):
-        """
-        Get transformed audio and context for the preceding audio
-        @param chunk: bytes of audio data
-        @return: transformed audio data, dict context
-        """
-        context = {
-            "client_name": "ovos_dinkum_listener",
-            "source": "audio",  # default native audio source
-            "destination": ["skills"],
-        }
-        for module in self.plugins:
-            try:
-                LOG.debug(f"checking audio transformer: {module}")
-                chunk = module.feed_speech_utterance(chunk)
-                chunk, data = module.transform(chunk)
-                LOG.debug(f"{module.name}: {data}")
-                context = merge_dict(context, data)
-            except Exception as e:
-                LOG.exception(e)
-        return chunk, context
+    @classmethod
+    def find_plugins(cls):
+        return find_audio_transformer_plugins().items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ovos-plugin-manager>=2.5.0a1,<3.0.0",
+    "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "ovos-utils>=0.8.4,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
     "ovos_bus_client>=2.5.1a1,<3.0.0",

--- a/test/unittests/test_voice_loop_methods.py
+++ b/test/unittests/test_voice_loop_methods.py
@@ -445,9 +445,17 @@ class TestAfterCmd(unittest.TestCase):
         loop.stt_chunks = deque()
         loop.transformers.transform.return_value = (SILENT_CHUNK, {})
 
+        # the reset state depends on the vad_pre_wake_enabled setting,
+        # pin both values instead of inheriting the ovos-config default
+        loop.vad_pre_wake_enabled = False
         loop._after_cmd(SILENT_CHUNK)
-
         self.assertEqual(loop.state, ListeningState.DETECT_WAKEWORD)
+
+        loop.stt_audio_bytes = bytes()
+        loop.stt_chunks = deque()
+        loop.vad_pre_wake_enabled = True
+        loop._after_cmd(SILENT_CHUNK)
+        self.assertEqual(loop.state, ListeningState.PRE_WAKE_VAD)
 
     def test_resets_to_waiting_cmd_in_continuous_mode(self):
         """In CONTINUOUS mode, _after_cmd resets state to WAITING_CMD."""


### PR DESCRIPTION
## What

Replaces the local `AudioTransformersService` in `ovos_dinkum_listener/transformers.py` with a thin subclass of the canonical runner added to ovos-plugin-manager in OpenVoiceOS/ovos-plugin-manager#410.

No behavior change: dinkum already ran the spec's OVOS-TRANSFORM §4 ascending priority order, and the default message context (`client_name`/`source`/`destination`) is preserved. New via the canonical runner: explicit `"order"` chain support (§4) and the §8.1 cancellation contract. The legacy `listener.audio_transformers` config location keeps working; a top-level `audio_transformers` section is now also supported and preferred.

## Depends on

- OpenVoiceOS/ovos-plugin-manager#410 — must merge and release first; this PR pins `ovos-plugin-manager>=2.10.0a1`. CI stays red until that alpha is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)