### PR TITLE
feat: opt-in open_data upload of wake word and stt samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,38 @@ non exhaustive list of config options
 }
 ```
 
+## Open data uploads
+
+`ovos-dinkum-listener` can optionally upload wake word and STT audio samples to an
+[ovos-opendata-server](https://github.com/OpenVoiceOS/ovos-opendata-server) instance,
+so users and developers can donate samples to help improve wake word and STT plugins.
+
+**This is exclusively opt-in and off by default.** Nothing is ever uploaded unless
+you explicitly configure at least one `ww_urls` or `stt_urls` endpoint below - there
+is no default server. This pairs with the intent-match metrics upload already
+supported by `ovos-core` (`open_data.intent_urls`).
+
+```json
+{
+  "open_data": {
+    "ww_urls": ["https://your-opendata-server.example/api/wake_word"],
+    "stt_urls": ["https://your-opendata-server.example/api/stt"],
+    "user_agent": "ovos-metrics",
+    "api_key": null
+  }
+}
+```
+
+- `ww_urls` - list of server URLs to POST wake word samples to (`name`, `audio`, `model`,
+  `lang`, `plugin`, `plugin_config`). Leave unset/empty to disable wake word uploads.
+- `stt_urls` - list of server URLs to POST STT samples to (`transcript`, `lang`, `audio`,
+  `model`, `plugin`, `plugin_config`). Leave unset/empty to disable STT uploads.
+- `user_agent` - `User-Agent` header sent with uploads, defaults to `"ovos-metrics"`.
+- `api_key` - optional, sent as the `X-API-Key` header if set.
+
+Uploads happen in a background thread and never block the listener; failures are
+logged and otherwise ignored.
+
 ## Tips and tricks
 
 ### Saving Transcriptions

--- a/ovos_dinkum_listener/opendata.py
+++ b/ovos_dinkum_listener/opendata.py
@@ -1,0 +1,126 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Opt-in upload of wake word / STT audio samples to an ovos-opendata-server.
+
+Nothing is uploaded unless the user explicitly configures one or more
+target URLs under the ``open_data`` section of mycroft.conf. There is no
+default server - this is purely opt-in metrics/dataset collection to help
+improve wake word and STT plugins.
+
+https://github.com/OpenVoiceOS/ovos-opendata-server
+"""
+from typing import List, Optional
+
+import requests
+from ovos_config import Configuration
+from ovos_utils.log import LOG
+from ovos_utils.thread_utils import create_daemon
+
+
+def _get_urls(key: str) -> List[str]:
+    config = Configuration().get("open_data", {})
+    endpoints = config.get(key, [])
+    if isinstance(endpoints, str):
+        endpoints = [endpoints]
+    return endpoints
+
+
+def _headers() -> dict:
+    config = Configuration().get("open_data", {})
+    headers = {"User-Agent": config.get("user_agent", "ovos-metrics")}
+    api_key = config.get("api_key")
+    if api_key:
+        headers["X-API-Key"] = api_key
+    return headers
+
+
+def _post_multipart(url: str, wav_bytes: bytes, data: dict):
+    files = {"audio": ("sample.wav", wav_bytes, "audio/wav")}
+    try:
+        response = requests.post(url, data=data, files=files,
+                                  headers=_headers(), timeout=5)
+        LOG.info(f"Uploaded open_data sample to '{url}' - "
+                 f"Response: {response.status_code}")
+    except Exception as e:
+        LOG.warning(f"Failed to upload open_data sample to '{url}': {e}")
+
+
+def _upload_wake_word_sample(wav_bytes: bytes, name: str,
+                              lang: Optional[str] = None,
+                              model: Optional[str] = None,
+                              plugin: Optional[str] = None,
+                              plugin_config: Optional[str] = None):
+    urls = _get_urls("ww_urls")
+    if not urls or not name:
+        return
+    data = {"name": name}
+    if lang:
+        data["lang"] = lang
+    if model:
+        data["model"] = model
+    if plugin:
+        data["plugin"] = plugin
+    if plugin_config:
+        data["plugin_config"] = plugin_config
+    for url in urls:
+        _post_multipart(url, wav_bytes, data)
+
+
+def _upload_stt_sample(wav_bytes: bytes, transcript: str, lang: str,
+                        model: Optional[str] = None,
+                        plugin: Optional[str] = None,
+                        plugin_config: Optional[str] = None):
+    urls = _get_urls("stt_urls")
+    if not urls or not transcript or not lang:
+        return
+    data = {"transcript": transcript, "lang": lang}
+    if model:
+        data["model"] = model
+    if plugin:
+        data["plugin"] = plugin
+    if plugin_config:
+        data["plugin_config"] = plugin_config
+    for url in urls:
+        _post_multipart(url, wav_bytes, data)
+
+
+def upload_wake_word_sample(wav_bytes: bytes, name: str,
+                             lang: Optional[str] = None,
+                             model: Optional[str] = None,
+                             plugin: Optional[str] = None,
+                             plugin_config: Optional[str] = None):
+    """If the user configured ``open_data.ww_urls``, upload a wake word
+    sample (wav bytes + metadata) to each configured server, in a daemon
+    thread so it never blocks the listener.
+
+    No-op unless ``open_data.ww_urls`` is configured - exclusively opt-in.
+    """
+    if not _get_urls("ww_urls"):
+        return
+    create_daemon(_upload_wake_word_sample,
+                  (wav_bytes, name, lang, model, plugin, plugin_config))
+
+
+def upload_stt_sample(wav_bytes: bytes, transcript: str, lang: str,
+                       model: Optional[str] = None,
+                       plugin: Optional[str] = None,
+                       plugin_config: Optional[str] = None):
+    """If the user configured ``open_data.stt_urls``, upload an STT
+    sample (wav bytes + transcript + metadata) to each configured server,
+    in a daemon thread so it never blocks the listener.
+
+    No-op unless ``open_data.stt_urls`` is configured - exclusively opt-in.
+    """
+    if not _get_urls("stt_urls"):
+        return
+    create_daemon(_upload_stt_sample,
+                  (wav_bytes, transcript, lang, model, plugin, plugin_config))

--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
+import io
 import json
 import random
 import wave
@@ -52,6 +53,7 @@ from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap, ProcessSt
 
 import warnings
 from ovos_dinkum_listener._util import _TemplateFilenameFormatter
+from ovos_dinkum_listener.opendata import upload_wake_word_sample, upload_stt_sample
 from ovos_dinkum_listener.plugins import (
     load_stt_module,
     load_fallback_stt,
@@ -599,6 +601,18 @@ class OVOSDinkumVoiceService(Thread):
             )
         self.bus.emit(Message(SpecMessage.LISTENER_RECORD_STARTED))
 
+    def _wav_bytes(self, audio_bytes: bytes) -> bytes:
+        """Wrap raw PCM frames in an in-memory WAV container using the
+        current microphone's audio parameters."""
+        mic = self.voice_loop.mic
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav_file:
+            wav_file.setframerate(mic.sample_rate)
+            wav_file.setsampwidth(mic.sample_width)
+            wav_file.setnchannels(mic.sample_channels)
+            wav_file.writeframes(audio_bytes)
+        return buf.getvalue()
+
     def _save_ww(self, audio_bytes, ww_meta, save_path=None):
         if save_path:
             hotword_audio_dir = Path(save_path)
@@ -663,6 +677,16 @@ class OVOSDinkumVoiceService(Thread):
             listener = self.config["listener"]
             if listener["record_wake_words"]:
                 payload["filename"] = self._save_ww(audio_bytes, ww_context)
+
+            try:
+                upload_wake_word_sample(
+                    self._wav_bytes(audio_bytes),
+                    name=ww_context.get("key_phrase"),
+                    lang=stt_lang or Configuration().get("lang"),
+                    plugin=ww_context.get("module"),
+                )
+            except Exception:
+                LOG.exception("Error while uploading open_data wake word sample")
 
             utterance = ww_context.get("utterance")
             if utterance:
@@ -829,6 +853,22 @@ class OVOSDinkumVoiceService(Thread):
                 stt_context["filename"] = self._save_stt(audio_bytes, stt_context)
         except Exception:
             LOG.exception("Error while saving STT audio")
+
+        try:
+            try:
+                transcript = stt_context.get("transcriptions", [(None,)])[0][0]
+            except IndexError:
+                transcript = None
+            transcript = transcript or stt_context.get("transcription")
+            lang = stt_context.get("lang") or Configuration().get("lang")
+            upload_stt_sample(
+                self._wav_bytes(audio_bytes),
+                transcript=transcript,
+                lang=lang,
+                plugin=self.config.get("stt", {}).get("module"),
+            )
+        except Exception:
+            LOG.exception("Error while uploading open_data STT sample")
         return stt_context
 
     def _save_recording(self, audio_bytes, stt_meta, save_path=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "ovos-config>=1.2.2,<3.0.0",
     "ovos_bus_client>=2.5.1a1,<3.0.0",
     "ovos-spec-tools>=0.16.1a2",
+    "requests>=2.26, <3.0",
     "audioop-lts; python_version >= '3.13'",  # removed from stdlib in py 3.13
 ]
 

--- a/test/unittests/test_opendata.py
+++ b/test/unittests/test_opendata.py
@@ -1,0 +1,142 @@
+"""Unit tests for ovos_dinkum_listener.opendata (opt-in open_data uploads)."""
+import unittest
+from unittest.mock import patch, Mock
+
+from ovos_dinkum_listener import opendata
+
+
+class TestUploadWakeWordSample(unittest.TestCase):
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_no_op_when_not_configured(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {}
+        opendata.upload_wake_word_sample(b"RIFF....WAVE", name="hey_mycroft")
+        mock_post.assert_not_called()
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_uploads_to_configured_urls(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {
+            "ww_urls": ["http://a.example/ww", "http://b.example/ww"],
+            "user_agent": "custom-agent",
+        }
+        mock_post.return_value = Mock(status_code=200)
+
+        opendata._upload_wake_word_sample(
+            b"RIFF....WAVE", name="hey_mycroft", lang="en-us",
+            model="1234", plugin="ovos-ww-plugin-precise",
+        )
+
+        self.assertEqual(mock_post.call_count, 2)
+        for call in mock_post.call_args_list:
+            args, kwargs = call
+            self.assertIn(args[0], ("http://a.example/ww", "http://b.example/ww"))
+            self.assertEqual(kwargs["data"]["name"], "hey_mycroft")
+            self.assertEqual(kwargs["data"]["lang"], "en-us")
+            self.assertEqual(kwargs["data"]["model"], "1234")
+            self.assertEqual(kwargs["data"]["plugin"], "ovos-ww-plugin-precise")
+            self.assertIn("audio", kwargs["files"])
+            self.assertEqual(kwargs["headers"]["User-Agent"], "custom-agent")
+            self.assertNotIn("X-API-Key", kwargs["headers"])
+            self.assertEqual(kwargs["timeout"], 5)
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_api_key_header_included(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {
+            "ww_urls": ["http://a.example/ww"],
+            "api_key": "secret123",
+        }
+        mock_post.return_value = Mock(status_code=200)
+
+        opendata._upload_wake_word_sample(b"RIFF....WAVE", name="hey_mycroft")
+
+        kwargs = mock_post.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["X-API-Key"], "secret123")
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_no_op_without_name(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {"ww_urls": ["http://a.example/ww"]}
+        opendata._upload_wake_word_sample(b"RIFF....WAVE", name=None)
+        mock_post.assert_not_called()
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_errors_are_swallowed(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {"ww_urls": ["http://a.example/ww"]}
+        mock_post.side_effect = Exception("boom")
+        # should not raise
+        opendata._upload_wake_word_sample(b"RIFF....WAVE", name="hey_mycroft")
+
+    @patch("ovos_dinkum_listener.opendata.create_daemon")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_public_upload_wake_word_uses_daemon_thread(self, mock_config, mock_daemon):
+        mock_config.return_value.get.return_value = {"ww_urls": ["http://a.example/ww"]}
+        opendata.upload_wake_word_sample(b"RIFF....WAVE", name="hey_mycroft")
+        mock_daemon.assert_called_once()
+        self.assertEqual(mock_daemon.call_args[0][0], opendata._upload_wake_word_sample)
+
+    @patch("ovos_dinkum_listener.opendata.create_daemon")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_public_upload_wake_word_no_op_without_urls(self, mock_config, mock_daemon):
+        mock_config.return_value.get.return_value = {}
+        opendata.upload_wake_word_sample(b"RIFF....WAVE", name="hey_mycroft")
+        mock_daemon.assert_not_called()
+
+
+class TestUploadSttSample(unittest.TestCase):
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_no_op_when_not_configured(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {}
+        opendata.upload_stt_sample(b"RIFF....WAVE", transcript="hello", lang="en-us")
+        mock_post.assert_not_called()
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_uploads_to_configured_urls(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {
+            "stt_urls": ["http://a.example/stt"],
+        }
+        mock_post.return_value = Mock(status_code=200)
+
+        opendata._upload_stt_sample(
+            b"RIFF....WAVE", transcript="hello world", lang="en-us",
+            model="whisper-base", plugin="ovos-stt-plugin-server",
+        )
+
+        mock_post.assert_called_once()
+        kwargs = mock_post.call_args.kwargs
+        self.assertEqual(kwargs["data"]["transcript"], "hello world")
+        self.assertEqual(kwargs["data"]["lang"], "en-us")
+        self.assertEqual(kwargs["data"]["model"], "whisper-base")
+        self.assertEqual(kwargs["data"]["plugin"], "ovos-stt-plugin-server")
+        self.assertIn("audio", kwargs["files"])
+        self.assertEqual(kwargs["headers"]["User-Agent"], "ovos-metrics")
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_no_op_without_transcript_or_lang(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {"stt_urls": ["http://a.example/stt"]}
+        opendata._upload_stt_sample(b"RIFF....WAVE", transcript=None, lang="en-us")
+        opendata._upload_stt_sample(b"RIFF....WAVE", transcript="hi", lang=None)
+        mock_post.assert_not_called()
+
+    @patch("ovos_dinkum_listener.opendata.requests.post")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_errors_are_swallowed(self, mock_config, mock_post):
+        mock_config.return_value.get.return_value = {"stt_urls": ["http://a.example/stt"]}
+        mock_post.side_effect = Exception("boom")
+        opendata._upload_stt_sample(b"RIFF....WAVE", transcript="hello", lang="en-us")
+
+    @patch("ovos_dinkum_listener.opendata.create_daemon")
+    @patch("ovos_dinkum_listener.opendata.Configuration")
+    def test_public_upload_stt_no_op_without_urls(self, mock_config, mock_daemon):
+        mock_config.return_value.get.return_value = {}
+        opendata.upload_stt_sample(b"RIFF....WAVE", transcript="hello", lang="en-us")
+        mock_daemon.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a small `ovos_dinkum_listener/opendata.py` uploader that POSTs wake word and STT audio samples (multipart, in-memory WAV bytes) to an [ovos-opendata-server](https://github.com/OpenVoiceOS/ovos-opendata-server) instance, mirroring the style of `ovos-core`'s existing `_upload_match_data` intent-metrics upload.
- Exclusively opt-in and off by default: uploads only happen if `open_data.ww_urls` / `open_data.stt_urls` are explicitly configured; there is no default server. Uploads run in a daemon thread, errors are logged and swallowed.
- Wired into `_hotword_audio` (wake word capture) and `_stt_audio` (utterance capture) in `ovos_dinkum_listener/service.py`, independent of the existing local-save config (`record_wake_words` / `save_utterances`), which is unchanged.
- Pairs with `ovos-core`'s `open_data.intent_urls` intent-match metrics upload and a companion config-schema PR in `ovos-config`.

## Test plan
- [x] New unit tests in `test/unittests/test_opendata.py`: no-op with empty config, correct fields/headers when `ww_urls`/`stt_urls` set, `X-API-Key` header when `api_key` configured, errors swallowed, daemon-thread dispatch, no-op without required fields (name / transcript+lang).
- [x] Full suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/ -q` -> 292 passed, 7 skipped (pre-existing skips, unrelated to this change).

Model usage: implemented by Claude Sonnet under Fable orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)