### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# OpenVoiceOS Dinkum Listener 
+# OpenVoiceOS Dinkum Listener
 
-Documentation can be found in [the technical manual](https://openvoiceos.github.io/ovos-technical-manual/speech_service/)
+`ovos-dinkum-listener` is the voice input daemon for [OpenVoiceOS](https://openvoiceos.com). It reads audio from the microphone, runs it through a wakeword, VAD, and STT pipeline, and emits the results on the message bus for the rest of OVOS to use.
+
+Full documentation lives in [the technical manual](https://openvoiceos.github.io/ovos-technical-manual/speech_service/) and in [docs/](docs/index.md).
 
 ## Install
 
@@ -211,6 +213,17 @@ Then start the listener and observe logs — a detected wake word followed by
 `"wake word verifier plugins discarded detection"` means the verifier rejected
 the audio (expected on a non-speech trigger).
 
+## Related projects
+
+- [OpenVoiceOS/ovos-core](https://github.com/OpenVoiceOS/ovos-core) - the assistant core that runs this listener
+- [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager) - discovers and loads the STT, VAD, wakeword, and audio transformer plugins used here
+- [OpenVoiceOS/ovos-utterance-corrections-plugin](https://github.com/OpenVoiceOS/ovos-utterance-corrections-plugin) - fixes recurring STT transcription errors
+- [OpenVoiceOS/ovos-microphone-plugin-sounddevice](https://github.com/OpenVoiceOS/ovos-microphone-plugin-sounddevice) - microphone plugin for MacOS
+
 ## Credits
 
 Voice Loop state machine implementation by [@Synesthesiam](https://github.com/synesthesiam) for [mycroft-dinkum](https://github.com/MycroftAI/mycroft-dinkum)
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/docs/hotwords.md
+++ b/docs/hotwords.md
@@ -7,15 +7,15 @@
 
 ---
 
-## `HotWordException` — `hotwords.py:18`
+## `HotWordException` - `hotwords.py:18`
 
-Raised by `HotwordContainer.found()` when the current `HotwordState` is `LISTEN` but no listen words are loaded. Signals a configuration error — the listener has no way to exit the waiting state.
+Raised by `HotwordContainer.found()` when the current `HotwordState` is `LISTEN` but no listen words are loaded. Signals a configuration error - the listener has no way to exit the waiting state.
 
 ---
 
-## `CyclicAudioBuffer` — `hotwords.py:22`
+## `CyclicAudioBuffer` - `hotwords.py:22`
 
-A fixed-size sliding window of audio bytes. New data is appended; oldest data is dropped when capacity is exceeded.
+A fixed-size sliding window of audio bytes. New data is appended, oldest data is dropped when capacity is exceeded.
 
 ```python
 from ovos_dinkum_listener.voice_loop.hotwords import CyclicAudioBuffer
@@ -25,32 +25,32 @@ buf.append(chunk)
 audio = buf.get()
 ```
 
-### Constructor — `hotwords.py:30`
+### Constructor - `hotwords.py:30`
 
 | Parameter | Default | Description |
 |---|---|---|
 | `duration` | `0.98` | Window size in seconds |
-| `initial_data` | `None` | Seed data; defaults to silence |
+| `initial_data` | `None` | Seed data, defaults to silence |
 | `sample_rate` | `16000` | Sample rate for byte-size calculation |
 | `sample_width` | `2` | Sample width in bytes |
 
-`self.size = duration_to_bytes(duration, sample_rate, sample_width)` — `hotwords.py:32`
+`self.size = duration_to_bytes(duration, sample_rate, sample_width)` - `hotwords.py:32`
 
-Initial buffer: the last `size` bytes of `initial_data`, or silence. — `hotwords.py:35`
+Initial buffer: the last `size` bytes of `initial_data`, or silence. - `hotwords.py:35`
 
 ### Methods
 
 | Method | Signature | Description |
 |---|---|---|
-| `append(data)` | `bytes → None` | Concatenate `_buffer + data`, then keep only the last `size` bytes — `hotwords.py:64` |
-| `get()` | `→ bytes` | Return current buffer contents — `hotwords.py:75` |
-| `clear()` | `→ None` | Reset buffer to `size` null bytes — `hotwords.py:37` |
-| `duration_to_bytes(duration, sr, sw)` | `static → int` | `int(duration * sr) * sw` — `hotwords.py:44` |
-| `get_silence(num_bytes)` | `static → bytes` | Return `b'\0' * num_bytes` — `hotwords.py:56` |
+| `append(data)` | `bytes → None` | Concatenate `_buffer + data`, then keep only the last `size` bytes - `hotwords.py:64` |
+| `get()` | `→ bytes` | Return current buffer contents - `hotwords.py:75` |
+| `clear()` | `→ None` | Reset buffer to `size` null bytes - `hotwords.py:37` |
+| `duration_to_bytes(duration, sr, sw)` | `static → int` | `int(duration * sr) * sw` - `hotwords.py:44` |
+| `get_silence(num_bytes)` | `static → bytes` | Return `b'\0' * num_bytes` - `hotwords.py:56` |
 
 ---
 
-## `HotwordState` — `hotwords.py:82`
+## `HotwordState` - `hotwords.py:82`
 
 Controls which engine subset receives audio in `update()` and is checked in `found()`.
 
@@ -59,17 +59,17 @@ Controls which engine subset receives audio in `update()` and is checked in `fou
 | `LISTEN` | `"wakeword"` | `listen_words` | Default WW detection |
 | `HOTWORD` | `"hotword"` | `hot_words` | Continuous/hybrid mode (non-listen hotwords) |
 | `RECORDING` | `"recording"` | `stop_words` | During free recording |
-| `WAKEUP` | `"wakeup"` | `wakeup_words` | While sleeping; looking for wakeup word |
+| `WAKEUP` | `"wakeup"` | `wakeup_words` | While sleeping, looking for wakeup word |
 
 ---
 
-## `_safe_get_plugins` decorator — `hotwords.py:90`
+## `_safe_get_plugins` decorator - `hotwords.py:90`
 
-Wraps `HotwordContainer` property accessors. Blocks on `HotwordContainer._loaded.wait(30)` — raises `TimeoutError` if engines are not loaded within 30 seconds. Converts `KeyError` to `HotWordException`.
+Wraps `HotwordContainer` property accessors. Blocks on `HotwordContainer._loaded.wait(30)` - raises `TimeoutError` if engines are not loaded within 30 seconds. Converts `KeyError` to `HotWordException`.
 
 ---
 
-## `HotwordContainer` — `hotwords.py:102`
+## `HotwordContainer` - `hotwords.py:102`
 
 Class-level shared plugin registry. All instances share `_plugins` (dict) and `_loaded` (`threading.Event`).
 
@@ -80,12 +80,12 @@ container = HotwordContainer(bus)
 container.load_hotword_engines()
 ```
 
-### Constructor — `hotwords.py:106`
+### Constructor - `hotwords.py:106`
 
 | Parameter | Default | Description |
 |---|---|---|
 | `bus` | `FakeBus()` | Message bus for binding hotword plugins |
-| `expected_duration` | `3` | Reserved; not currently used in FSM logic |
+| `expected_duration` | `3` | Reserved, not currently used in FSM logic |
 | `sample_rate` | `16000` | Audio sample rate |
 | `sample_width` | `2` | Audio sample width in bytes |
 | `reload_allowed` | `True` | If `False`, `load_hotword_engines()` is a no-op after first load |
@@ -96,22 +96,22 @@ Initial state: `HotwordState.HOTWORD`, `reload_on_failure = False`.
 **Important:** `_plugins` and `_loaded` are **class attributes** (not instance attributes). Resetting them affects all instances:
 
 ```python
-# In tests — reset class state between test cases:
+# In tests - reset class state between test cases:
 HotwordContainer._plugins = {}
 HotwordContainer._loaded = Event()
 ```
 
-### `load_hotword_engines()` — `hotwords.py:116`
+### `load_hotword_engines()` - `hotwords.py:116`
 
 Reads `mycroft.conf["hotwords"]` and loads the configured engines.
 
 Key behaviours:
-- Skips reload if `reload_allowed=False` and `_loaded` is already set — `hotwords.py:120`
-- Normalises hotword names: spaces → underscores — `hotwords.py:145`
-- Auto-enables main WW and stand-up word when `active` is `None` — `hotwords.py:158`
-- Retrieves sound duration from audio file if `sound` is set — `hotwords.py:195`
-- Sets `_loaded` event when done — `hotwords.py:208`
-- Sets `reload_on_failure = True` if at least one listen word was loaded — `hotwords.py:213`
+- Skips reload if `reload_allowed=False` and `_loaded` is already set - `hotwords.py:120`
+- Normalises hotword names: spaces → underscores - `hotwords.py:145`
+- Auto-enables main WW and stand-up word when `active` is `None` - `hotwords.py:158`
+- Retrieves sound duration from audio file if `sound` is set - `hotwords.py:195`
+- Sets `_loaded` event when done - `hotwords.py:208`
+- Sets `reload_on_failure = True` if at least one listen word was loaded - `hotwords.py:213`
 
 Per-plugin record stored in `_plugins[word]`:
 
@@ -120,12 +120,12 @@ Per-plugin record stored in `_plugins[word]`:
     "engine": HotWordEngine,  # plugin instance
     "sound": "snd/start_listening.wav",  # or None
     "bus_event": "custom.event",          # or None
-    "utterance": "run script",            # or None; hard-coded STT output
+    "utterance": "run script",            # or None, hard-coded STT output
     "stt_lang": "en-us",
     "listen": True,
     "wakeup": False,
     "stopword": False,
-    "sound_duration": 0.8,               # seconds; only if sound is set
+    "sound_duration": 0.8,               # seconds, only if sound is set
 }
 ```
 
@@ -138,12 +138,12 @@ Per-plugin record stored in `_plugins[word]`:
 | **Stop word** | `stopword: true` | Ends free `RECORDING` mode |
 | **Hotword** | none of the above (active=true) | Plays sound and/or emits bus event |
 
-Auto-enable rules (when `active` is `null`/`None`) — `hotwords.py:158`:
+Auto-enable rules (when `active` is `null`/`None`) - `hotwords.py:158`:
 - Main wake word (`listener.wake_word`) → enabled
 - Stand-up word (`listener.stand_up_word`) → enabled
 - All other hotwords → disabled
 
-### `update(chunk)` — `hotwords.py:312`
+### `update(chunk)` - `hotwords.py:312`
 
 Feeds `chunk` to all engines in the currently active subset (determined by `self.state`). Exceptions per-engine are caught and logged.
 
@@ -154,13 +154,13 @@ Feeds `chunk` to all engines in the currently active subset (determined by `self
 | `RECORDING` | `stop_words.values()` |
 | `HOTWORD` | `hot_words.values()` |
 
-### `found()` → `Optional[str]` — `hotwords.py:259`
+### `found()` → `Optional[str]` - `hotwords.py:259`
 
 Checks whether any engine in the active subset has fired. Returns the first matching hotword name, or `None`.
 
-Raises `HotWordException` if `state == LISTEN` and `listen_words` is empty — `hotwords.py:269`.
+Raises `HotWordException` if `state == LISTEN` and `listen_words` is empty - `hotwords.py:269`.
 
-### `get_ww(ww)` → `dict` — `hotwords.py:292`
+### `get_ww(ww)` → `dict` - `hotwords.py:292`
 
 Returns a copy of `_plugins[ww]` enriched with:
 - `"key_phrase"`: the hotword name
@@ -169,36 +169,36 @@ Returns a copy of `_plugins[ww]` enriched with:
 
 The `"engine"` field in the returned dict is the **class name string** (not the engine object).
 
-### `verify(ww_audio)` → `bool` — `hotwords.py:328`
+### `verify(ww_audio)` → `bool` - `hotwords.py:328`
 
 Runs every registered verifier plugin (`self.verifiers`) against the wake-word
 audio. Returns `False` as soon as any verifier returns `False` (the detection is
-discarded); returns `True` if all accept or none are configured.
+discarded), returns `True` if all accept or none are configured.
 
-**Fail-open:** a verifier that *raises* is logged and skipped — only an explicit
+**Fail-open:** a verifier that *raises* is logged and skipped - only an explicit
 `False` return suppresses the wake. Verifiers are loaded by the service from
 `listener.ww_verifiers` (see `MycroftDinkumService._load_ww_verifiers`).
 
-### `reset()` — `hotwords.py:336`
+### `reset()` - `hotwords.py:336`
 
 Calls `engine.reset()` on all loaded engines (if the method exists). Called after each utterance to prevent stale model state.
 
-### `shutdown()` — `hotwords.py:348`
+### `shutdown()` - `hotwords.py:348`
 
 Calls `engine.shutdown()` on all engines, then removes all entries from `_plugins`.
 
 ### Properties
 
-`ww_names` reads `_plugins` directly and is **not** guarded by `@_safe_get_plugins` — it does not wait on `_loaded` and will not raise `HotWordException`. All other properties below are decorated with `@_safe_get_plugins` and block until engines are loaded.
+`ww_names` reads `_plugins` directly and is **not** guarded by `@_safe_get_plugins` - it does not wait on `_loaded` and will not raise `HotWordException`. All other properties below are decorated with `@_safe_get_plugins` and block until engines are loaded.
 
 | Property | Returns | Guarded | Description |
 |---|---|---|---|
-| `ww_names` | `[str, ...]` | No | All loaded hotword names — `hotwords.py:220` |
-| `listen_words` | `{name: engine}` | Yes | Engines with `listen: true` — `hotwords.py:238` |
-| `wakeup_words` | `{name: engine}` | Yes | Engines with `wakeup: true` — `hotwords.py:231` |
-| `stop_words` | `{name: engine}` | Yes | Engines with `stopword: true` — `hotwords.py:244` |
-| `hot_words` | `{name: engine}` | Yes | Engines that are not listen, wakeup, or stop — `hotwords.py:251` |
-| `plugins` | `[engine, ...]` | Yes | All loaded engine instances — `hotwords.py:226` |
+| `ww_names` | `[str, ...]` | No | All loaded hotword names - `hotwords.py:220` |
+| `listen_words` | `{name: engine}` | Yes | Engines with `listen: true` - `hotwords.py:238` |
+| `wakeup_words` | `{name: engine}` | Yes | Engines with `wakeup: true` - `hotwords.py:231` |
+| `stop_words` | `{name: engine}` | Yes | Engines with `stopword: true` - `hotwords.py:244` |
+| `hot_words` | `{name: engine}` | Yes | Engines that are not listen, wakeup, or stop - `hotwords.py:251` |
+| `plugins` | `[engine, ...]` | Yes | All loaded engine instances - `hotwords.py:226` |
 
 ---
 
@@ -243,23 +243,23 @@ Each entry under `hotwords` in `mycroft.conf`:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `module` | `str` | — | OPM entry point name for the hotword plugin |
-| `active` | `bool\|null` | `null` | `true` to load; auto-enabled for main WW and stand-up word |
+| `module` | `str` | - | OPM entry point name for the hotword plugin |
+| `active` | `bool\|null` | `null` | `true` to load, auto-enabled for main WW and stand-up word |
 | `listen` | `bool` | `false` | Triggers the VAD/STT recording pipeline |
 | `wakeup` | `bool` | `false` | Exits sleep mode |
 | `stopword` | `bool` | `false` | Ends free recording mode |
-| `sound` | `str\|list` | — | Sound file played on detection |
-| `bus_event` | `str` | — | Bus message type emitted on detection |
-| `utterance` | `str` | — | Hard-coded utterance bypassing STT |
+| `sound` | `str\|list` | - | Sound file played on detection |
+| `bus_event` | `str` | - | Bus message type emitted on detection |
+| `utterance` | `str` | - | Hard-coded utterance bypassing STT |
 | `stt_lang` | `str` | global lang | Override STT language for the following command |
 
 ### Global Listening Sound
 
-If `confirm_listening: true` is set in config and a listen word has no `sound`, the sound is taken from `sounds.start_listening` — `hotwords.py:165`.
+If `confirm_listening: true` is set in config and a listen word has no `sound`, the sound is taken from `sounds.start_listening` - `hotwords.py:165`.
 
 ---
 
-## Sound Duration Detection — `hotwords.py:193`
+## Sound Duration Detection - `hotwords.py:193`
 
 When a hotword has a `sound` path, `get_sound_duration()` is called to determine the `CONFIRMATION` state duration. For paths starting with `"snd/"`, the path is resolved relative to the package `res/` directory.
 
@@ -282,3 +282,6 @@ def setUp(self):
 ```
 
 See `test/unittests/test_hotwords.py` for full test suite covering `CyclicAudioBuffer`, `HotwordContainer.found()`, `update()`, `reset()`, `shutdown()`, and `load_hotword_engines()`.
+
+---
+[← Voice Loop](voice-loop.md) · [Home](index.md) · [Service →](service.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ continuously reads audio from the microphone, runs it through a deterministic fi
 | Voice Activity Detection | Determines speech start/end boundaries using a `VADEngine` plugin |
 | STT transcription | Streams accumulated audio to a `StreamingSTT` plugin (with optional fallback) |
 | Audio transformation | Runs audio through `AudioTransformersService` before and after STT |
-| Bus integration | Reports recording lifecycle, transcription results; handles remote listen/mute/sleep/state controls |
+| Bus integration | Reports recording lifecycle, transcription results, handles remote listen/mute/sleep/state controls |
 | Audio saving | Optionally saves utterance, hotword, and recording audio to disk with JSON metadata |
 
 ---
@@ -40,13 +40,13 @@ OVOSDinkumVoiceService (Thread)             service.py:84
             ├── PRE_WAKE_VAD        ← gate wakeword on speech presence (optional)
             ├── DETECT_WAKEWORD     ← feed audio to hotword engines
             ├── WAITING_CMD         ← continuous mode: accumulate audio until speech
-            ├── CONFIRMATION        ← playing listen sound; no STT buffering yet
+            ├── CONFIRMATION        ← playing listen sound, no STT buffering yet
             ├── BEFORE_COMMAND      ← waiting for VAD to confirm speech started
-            ├── IN_COMMAND          ← VAD confirmed; streaming audio to STT
+            ├── IN_COMMAND          ← VAD confirmed, streaming audio to STT
             ├── AFTER_COMMAND       ← silence end: finalise STT, fire callbacks
             ├── RECORDING           ← free recording mode (stop-word or max-silence exits)
-            ├── SLEEPING            ← suppressed; wakeup-word only
-            └── CHECK_WAKE_UP       ← heard WW while sleeping; waiting for wakeup word
+            ├── SLEEPING            ← suppressed, wakeup-word only
+            └── CHECK_WAKE_UP       ← heard WW while sleeping, waiting for wakeup word
 ```
 
 ---
@@ -55,10 +55,10 @@ OVOSDinkumVoiceService (Thread)             service.py:84
 
 | Document | Contents |
 |---|---|
-| [voice-loop.md](voice-loop.md) | `DinkumVoiceLoop` FSM — states, modes, callbacks, timing, all config fields |
+| [voice-loop.md](voice-loop.md) | `DinkumVoiceLoop` FSM - states, modes, callbacks, timing, all config fields |
 | [hotwords.md](hotwords.md) | `HotwordContainer`, hotword types, `HotwordState`, `CyclicAudioBuffer` |
-| [service.md](service.md) | `OVOSDinkumVoiceService` — startup, bus events, config reload, audio saving |
-| [transformers.md](transformers.md) | `AudioTransformersService` — feed methods, transform pipeline, plugin API |
+| [service.md](service.md) | `OVOSDinkumVoiceService` - startup, bus events, config reload, audio saving |
+| [transformers.md](transformers.md) | `AudioTransformersService` - feed methods, transform pipeline, plugin API |
 | [plugins.md](plugins.md) | STT loading, `FakeStreamingSTT`, fallback STT, plugin introspection bus API |
 
 ---
@@ -88,7 +88,7 @@ service.join()
 ```
 ovos_dinkum_listener/
 ├── __main__.py             # Entry point: ovos-dinkum-listener
-├── service.py              # OVOSDinkumVoiceService — main daemon thread
+├── service.py              # OVOSDinkumVoiceService - main daemon thread
 ├── voice_loop/
 │   ├── __init__.py         # Re-exports DinkumVoiceLoop, ListeningState, ListeningMode
 │   ├── voice_loop.py       # DinkumVoiceLoop FSM, VoiceLoop base, ChunkInfo
@@ -144,23 +144,23 @@ ovos_dinkum_listener/
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `stt.module` | `str` | — | OPM entry point name for the primary STT plugin |
-| `stt.fallback_module` | `str` | — | OPM entry point name for fallback STT |
+| `stt.module` | `str` | - | OPM entry point name for the primary STT plugin |
+| `stt.fallback_module` | `str` | - | OPM entry point name for fallback STT |
 
 ### Confirmation Sound
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `confirm_listening` | `bool` | `false` | Play a sound when wake word is detected |
-| `sounds.start_listening` | `str` | — | Path or name of the listen-start sound |
-| `sounds.end_listening` | `str` | — | Sound played when recording mode ends |
+| `sounds.start_listening` | `str` | - | Path or name of the listen-start sound |
+| `sounds.end_listening` | `str` | - | Sound played when recording mode ends |
 
 ### Miscellaneous
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `listener.fake_barge_in` | `bool` | `false` | Lower speaker volume during recording |
-| `listener.barge_in_volume` | `int` | `30` | Volume (0–100) during fake barge-in |
+| `listener.barge_in_volume` | `int` | `30` | Volume (0-100) during fake barge-in |
 | `listener.mute_during_output` | `bool` | `false` | Mute mic while audio is playing |
 | `filter_hallucinations` | `bool` | `true` | Remove known STT hallucinations from transcripts |
 | `hallucination_list` | `list[str]` | `[...]` | Additional strings to filter from STT output |
@@ -174,15 +174,15 @@ Each entry under `hotwords` in `mycroft.conf`:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `module` | `str` | — | OPM wake word plugin entry point |
-| `active` | `bool\|null` | `null` | `true` to load; auto-enabled for main WW and stand-up word |
+| `module` | `str` | - | OPM wake word plugin entry point |
+| `active` | `bool\|null` | `null` | `true` to load, auto-enabled for main WW and stand-up word |
 | `listen` | `bool` | `false` | Starts the STT recording flow |
 | `wakeup` | `bool` | `false` | Exits sleep mode |
 | `stopword` | `bool` | `false` | Ends free recording mode |
-| `sound` | `str\|list` | — | Sound file (or list of choices) played on detection |
-| `bus_event` | `str` | — | Bus message type emitted on detection |
-| `utterance` | `str` | — | Hard-coded utterance to emit instead of running STT |
-| `stt_lang` | `str` | — | Override STT language for commands following this word |
+| `sound` | `str\|list` | - | Sound file (or list of choices) played on detection |
+| `bus_event` | `str` | - | Bus message type emitted on detection |
+| `utterance` | `str` | - | Hard-coded utterance to emit instead of running STT |
+| `stt_lang` | `str` | - | Override STT language for commands following this word |
 
 ---
 
@@ -227,7 +227,7 @@ DinkumVoiceLoop.run()                       voice_loop.py:205
 | `recognizer_loop:hotword` | Non-listen hotword detected |
 | `recognizer_loop:wakeupword` | Wakeup word detected while sleeping |
 | `recognizer_loop:stopword` | Stop word detected during recording |
-| `recognizer_loop:utterance` | STT complete — `{"utterances": [...], "lang": "..."}` |
+| `recognizer_loop:utterance` | STT complete - `{"utterances": [...], "lang": "..."}` |
 | `recognizer_loop:speech.recognition.unknown` | STT returned empty or hallucination-only result |
 | `mycroft.awoken` | Voice loop exited sleep mode |
 | `mycroft.audio.play_sound` | Play the listen-start confirmation sound |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,7 +7,7 @@ Helpers for loading STT plugins and adapting non-streaming plugins to the `Strea
 
 ---
 
-## `load_stt_module(config=None)` → `StreamingSTT` — `plugins.py:81`
+## `load_stt_module(config=None)` → `StreamingSTT` - `plugins.py:81`
 
 Load the primary STT plugin from configuration.
 
@@ -18,16 +18,16 @@ stt = load_stt_module()                          # reads mycroft.conf["stt"]
 stt = load_stt_module({"module": "ovos-stt-plugin-whisper", ...})
 ```
 
-Behaviour — `plugins.py:88`:
+Behaviour - `plugins.py:88`:
 1. Uses `config or Configuration()["stt"]`
 2. Sets `stt_config["lang"]` to global `lang` if not already set
 3. Calls `OVOSSTTFactory.create(stt_config)`
-4. If the result is **not** a `StreamingSTT` → wraps in `FakeStreamingSTT` — `plugins.py:96`
+4. If the result is **not** a `StreamingSTT` → wraps in `FakeStreamingSTT` - `plugins.py:96`
 5. Returns the `StreamingSTT` (native or wrapped)
 
 ---
 
-## `load_fallback_stt(cfg=None)` → `Optional[StreamingSTT]` — `plugins.py:102`
+## `load_fallback_stt(cfg=None)` → `Optional[StreamingSTT]` - `plugins.py:102`
 
 Load the fallback STT plugin.
 
@@ -38,8 +38,8 @@ fallback = load_fallback_stt()
 ```
 
 Returns `None` if:
-- `stt.fallback_module` is not configured or is empty — `plugins.py:111`
-- Plugin instantiation raises any exception — `plugins.py:124`
+- `stt.fallback_module` is not configured or is empty - `plugins.py:111`
+- Plugin instantiation raises any exception - `plugins.py:124`
 
 Config resolution:
 1. Uses `cfg or Configuration()["stt"]`
@@ -51,9 +51,9 @@ Config resolution:
 
 ---
 
-## `FakeStreamingSTT` — `plugins.py:47`
+## `FakeStreamingSTT` - `plugins.py:47`
 
-Adapter that wraps a regular (non-streaming) `STT` plugin inside the `StreamingSTT` interface. All audio chunks are buffered internally; the underlying plugin is invoked once at transcription time.
+Adapter that wraps a regular (non-streaming) `STT` plugin inside the `StreamingSTT` interface. All audio chunks are buffered internally, the underlying plugin is invoked once at transcription time.
 
 ```python
 from ovos_dinkum_listener.plugins import FakeStreamingSTT
@@ -63,31 +63,31 @@ streaming = FakeStreamingSTT(engine=non_streaming_stt_instance, config={})
 
 This is used transparently by `load_stt_module()` and `load_fallback_stt()`.
 
-### Constructor — `plugins.py:48`
+### Constructor - `plugins.py:48`
 
 | Parameter | Description |
 |---|---|
 | `engine` | A non-streaming `STT` plugin instance |
 | `config` | Optional config dict passed to `StreamingSTT.__init__` |
 
-### `create_streaming_thread()` — `plugins.py:52`
+### `create_streaming_thread()` - `plugins.py:52`
 
 Creates and returns a `FakeStreamThread`. Reads `listener.sample_rate` (default `16000`) and `listener.sample_width` (default `2`) from `Configuration`.
 
 Requires `self.queue` to be set before calling (done by `stream_start()` in the parent class).
 
-### `transcribe(audio=None, lang=None)` → `List[Tuple[str, float]]` — `plugins.py:59`
+### `transcribe(audio=None, lang=None)` → `List[Tuple[str, float]]` - `plugins.py:59`
 
 | `audio` value | Behaviour |
 |---|---|
-| `None` | Reads from `self.stream.buffer.read()`, clears buffer — `plugins.py:64` |
-| `bytes` | Wraps in `AudioData` using stream sample rate/width — `plugins.py:69` |
-| `AudioData` | Passes directly to `engine.transcribe()` — `plugins.py:73` |
-| any other type | Raises `ValueError` — `plugins.py:76` |
+| `None` | Reads from `self.stream.buffer.read()`, clears buffer - `plugins.py:64` |
+| `bytes` | Wraps in `AudioData` using stream sample rate/width - `plugins.py:69` |
+| `AudioData` | Passes directly to `engine.transcribe()` - `plugins.py:73` |
+| any other type | Raises `ValueError` - `plugins.py:76` |
 
 ---
 
-## `FakeStreamThread` — `plugins.py:11`
+## `FakeStreamThread` - `plugins.py:11`
 
 Internal streaming thread used by `FakeStreamingSTT`. Buffers audio in a `ReadWriteStream` and invokes the real STT engine at the end.
 
@@ -100,7 +100,7 @@ thread.update(audio_bytes)     # buffer audio
 result = thread.finalize()     # transcribe and return string
 ```
 
-### Constructor — `plugins.py:13`
+### Constructor - `plugins.py:13`
 
 | Parameter | Type | Description |
 |---|---|---|
@@ -112,30 +112,30 @@ result = thread.finalize()     # transcribe and return string
 
 Creates `self.buffer = ReadWriteStream()`.
 
-### `update(chunk)` — `plugins.py:43`
+### `update(chunk)` - `plugins.py:43`
 
 Writes `chunk` to `self.buffer`. Called by `stream_data()` via the parent class.
 
-### `handle_audio_stream(audio, language)` — `plugins.py:39`
+### `handle_audio_stream(audio, language)` - `plugins.py:39`
 
 Iterates over `audio` (an iterable of byte chunks) and calls `update()` for each. Used when feeding a complete audio stream at once.
 
-### `finalize()` → `Optional[str]` — `plugins.py:20`
+### `finalize()` → `Optional[str]` - `plugins.py:20`
 
 Transcription finalisation:
 
-1. Returns `""` immediately if `self.buffer` is empty (falsy) — `plugins.py:23`
+1. Returns `""` immediately if `self.buffer` is empty (falsy) - `plugins.py:23`
 2. Reads all buffered audio via `self.buffer.read()`
 3. Wraps in `AudioData(raw, sample_rate, sample_width)`
 4. Calls `self.engine.execute(audio_data, self.language)`
 5. Clears the buffer
 6. Returns the transcript string
-7. On any exception: logs and returns `None` — `plugins.py:35`
+7. On any exception: logs and returns `None` - `plugins.py:35`
 
 Note: `finalize()` returns:
-- `""` — buffer was empty (no audio received)
-- `str` — successful transcription
-- `None` — engine raised an exception
+- `""` - buffer was empty (no audio received)
+- `str` - successful transcription
+- `None` - engine raised an exception
 
 ---
 
@@ -187,12 +187,12 @@ The voice loop interfaces with STT through three method calls:
 
 | Call site | Loop state | Method |
 |---|---|---|
-| `_detect_ww()` — `voice_loop.py:567` | WW detected | `stt.stream_start()` |
+| `_detect_ww()` - `voice_loop.py:567` | WW detected | `stt.stream_start()` |
 | `_before_cmd()` / `_in_cmd()` | BEFORE_COMMAND / IN_COMMAND | `stt.stream_data(chunk)` |
 | `_after_cmd()` via `_get_tx()` | AFTER_COMMAND | `stt.transcribe(lang=lang)` |
 
 When `remove_silence: true` and the STT is a `FakeStreamingSTT`, the loop also:
-- Reads and trims `stt.stream.buffer` directly via `_vad_remove_silence()` — `voice_loop.py:810`
+- Reads and trims `stt.stream.buffer` directly via `_vad_remove_silence()` - `voice_loop.py:810`
 
 ---
 
@@ -210,7 +210,7 @@ thread = FakeStreamThread(Queue(), "en-us", engine, 16000, 2)
 thread.update(b'\x00' * 100)
 assert thread.finalize() == "hello"
 
-# FakeStreamingSTT — set queue before create_streaming_thread()
+# FakeStreamingSTT - set queue before create_streaming_thread()
 with patch("ovos_dinkum_listener.plugins.Configuration") as mock_cfg:
     mock_cfg.return_value = {"listener": {"sample_rate": 16000, "sample_width": 2}}
     stt = FakeStreamingSTT(engine=Mock(), config={})
@@ -220,3 +220,6 @@ with patch("ovos_dinkum_listener.plugins.Configuration") as mock_cfg:
 ```
 
 See `test/unittests/test_plugins.py` for full test coverage.
+
+---
+[← Transformers](transformers.md) · [Home](index.md)

--- a/docs/service.md
+++ b/docs/service.md
@@ -1,13 +1,13 @@
 # OVOSDinkumVoiceService
 
 **Module:** `ovos_dinkum_listener.service`
-**Class:** `OVOSDinkumVoiceService` — `service.py:84`
+**Class:** `OVOSDinkumVoiceService` - `service.py:84`
 
 Top-level daemon for `ovos-dinkum-listener`. A `Thread` subclass that owns all sub-components, manages the voice loop lifecycle, handles all bus events, and persists audio to disk.
 
 ---
 
-## Constructor — `service.py:84`
+## Constructor - `service.py:84`
 
 ```python
 OVOSDinkumVoiceService(
@@ -28,13 +28,13 @@ OVOSDinkumVoiceService(
 |---|---|
 | `on_ready` / `on_error` / `on_stopping` / `on_alive` / `on_started` | `ProcessStatus` lifecycle callbacks |
 | `watchdog` | Called every `WATCHDOG_DELAY` (0.5s) for systemd watchdog keepalive |
-| `mic` | Pre-created `Microphone`; loaded via `OVOSMicrophoneFactory` if `None` |
-| `bus` | `MessageBusClient`; created automatically if `None` |
+| `mic` | Pre-created `Microphone`, loaded via `OVOSMicrophoneFactory` if `None` |
+| `bus` | `MessageBusClient`, created automatically if `None` |
 | `validate_source` | If `True`, only handle `mycroft.mic.listen` from native audio destinations |
-| `stt` | Pre-created `StreamingSTT`; disables auto-reload on config change if provided |
+| `stt` | Pre-created `StreamingSTT`, disables auto-reload on config change if provided |
 | `fallback_stt` | Pre-created fallback `StreamingSTT` |
-| `vad` | Pre-created `VADEngine`; loaded via `OVOSVADFactory` if `None` |
-| `hotwords` | Pre-created `HotwordContainer`; disables auto-reload on config change if provided |
+| `vad` | Pre-created `VADEngine`, loaded via `OVOSVADFactory` if `None` |
+| `hotwords` | Pre-created `HotwordContainer`, disables auto-reload on config change if provided |
 | `disable_fallback` | If `True`, never load the fallback STT plugin |
 
 Default microphone plugin: `ovos-microphone-plugin-alsa`.
@@ -66,7 +66,7 @@ After `voice_loop.run()` returns:
 
 ---
 
-## Voice Loop Initialisation — `_init_voice_loop()`
+## Voice Loop Initialisation - `_init_voice_loop()`
 
 Creates `DinkumVoiceLoop` with all callbacks wired to service methods. Key bindings:
 
@@ -100,7 +100,7 @@ If `stt` or `hotwords` were passed as constructor arguments, they are not reload
 
 ---
 
-## Source Validation — `_validate_message_context(message)`
+## Source Validation - `_validate_message_context(message)`
 
 Guards `mycroft.mic.listen` so that only messages targeted at native audio sources are processed. Native sources are configured via `Audio.native_sources` (default: `["debug_cli", "audio"]`).
 
@@ -110,7 +110,7 @@ Set `validate_source=False` in the constructor to disable this check.
 
 ---
 
-## Hallucination Filtering — `_stt_text()`
+## Hallucination Filtering - `_stt_text()`
 
 After STT, transcripts are filtered using a block list. Enabled by `filter_hallucinations: true` (default: `true`). Additional strings can be added via `hallucination_list` in config.
 
@@ -136,14 +136,14 @@ Config: `listener.mute_during_output: true` mutes the mic entirely during TTS pl
 
 ## Audio Saving
 
-### Save Path — `default_save_path` (property)
+### Save Path - `default_save_path` (property)
 
 Base path is `listener.save_path` or `{XDG_DATA_DIR}/listener/`. Three subdirectories:
-- `utterances/` — STT audio
-- `wake_words/` — hotword audio
-- `recordings/` — free recording audio
+- `utterances/` - STT audio
+- `wake_words/` - hotword audio
+- `recordings/` - free recording audio
 
-`default_save_path` is a **read-only property** — it cannot be assigned directly.
+`default_save_path` is a **read-only property** - it cannot be assigned directly.
 
 ### `_save_stt(stt_meta, save_path=None)`
 
@@ -161,7 +161,7 @@ Saves free recording audio to the `recordings/` subdirectory.
 
 ---
 
-## `_compile_ww_context(key_phrase, ww_module)` — static method
+## `_compile_ww_context(key_phrase, ww_module)` - static method
 
 Returns a wakeword context dict for the bus event:
 
@@ -180,9 +180,9 @@ The `"engine"` field is an MD5 hex digest of the module name string, not the cla
 
 ---
 
-## `_hotword_audio(audio, ww_data)` — callback
+## `_hotword_audio(audio, ww_data)` - callback
 
-Called for all hotword types (listen, stop, wakeup, hotword). The `ww_data["event"]` key (if set) is used as the custom bus event type. Note: the key is `"event"`, not `"bus_event"` — the internal plugin record uses `"bus_event"` but `get_ww()` maps it to `"event"` in the returned dict.
+Called for all hotword types (listen, stop, wakeup, hotword). The `ww_data["event"]` key (if set) is used as the custom bus event type. Note: the key is `"event"`, not `"bus_event"` - the internal plugin record uses `"bus_event"` but `get_ww()` maps it to `"event"` in the returned dict.
 
 ---
 
@@ -254,7 +254,7 @@ Response format for STT/WW queries:
 
 ---
 
-## `_handle_change_state(message)` — `recognizer_loop:state.set`
+## `_handle_change_state(message)` - `recognizer_loop:state.set`
 
 Accepts a message with `data` keys:
 - `"mode"` → sets `voice_loop.listen_mode` (e.g. `"wakeword"`, `"continuous"`, `"hybrid"`)
@@ -264,7 +264,7 @@ If only `"mode"` is given, the FSM state is also reset to the appropriate defaul
 
 ---
 
-## `_handle_b64_transcribe(message)` — `recognizer_loop:b64_transcribe`
+## `_handle_b64_transcribe(message)` - `recognizer_loop:b64_transcribe`
 
 1. Decodes base64 audio from `message.data["audio"]`
 2. Runs through `transformers.transform()`
@@ -289,3 +289,6 @@ with patch("ovos_dinkum_listener.service.OVOSMicrophoneFactory"), \
 ```
 
 See `test/unittests/test_service.py` and `test/unittests/test_service_extended.py` for lifecycle and handler tests.
+
+---
+[← Hotwords](hotwords.md) · [Home](index.md) · [Transformers →](transformers.md)

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1,7 +1,7 @@
 # AudioTransformersService
 
 **Module:** `ovos_dinkum_listener.transformers`
-**Class:** `AudioTransformersService` — `transformers.py:34`
+**Class:** `AudioTransformersService` - `transformers.py:34`
 
 Manages a prioritised pipeline of audio transformer plugins. Plugins can inspect and modify raw audio before and during STT processing, and can inject metadata into the utterance context (e.g. detected language) that is merged into `recognizer_loop:utterance`.
 
@@ -19,18 +19,18 @@ Config is read from `config["listener"]["audio_transformers"]`. If no config is 
 
 ---
 
-## Constructor — `transformers.py:36`
+## Constructor - `transformers.py:36`
 
 | Parameter | Description |
 |---|---|
-| `bus` | Message bus client; bound to each plugin via `plugin.bind(bus)` |
+| `bus` | Message bus client, bound to each plugin via `plugin.bind(bus)` |
 | `config` | Full config dict (e.g. `Configuration()`). `None` defaults to `{}` |
 
-On construction, `load_plugins()` is called immediately — `transformers.py:44`.
+On construction, `load_plugins()` is called immediately - `transformers.py:44`.
 
 ---
 
-## Plugin Discovery and Loading — `load_plugins()` — `transformers.py:46`
+## Plugin Discovery and Loading - `load_plugins()` - `transformers.py:46`
 
 Discovers all installed audio transformer plugins via `find_audio_transformer_plugins()` (OPM entry point group: `opm.audio_transformer`).
 
@@ -54,11 +54,11 @@ A plugin is loaded only if:
 
 Each loaded plugin is instantiated with `plug()` and bound to the bus with `plugin.bind(bus)`. Load errors are logged and skipped.
 
-Sets `self.has_loaded = True` when done — `transformers.py:59`.
+Sets `self.has_loaded = True` when done - `transformers.py:59`.
 
 ---
 
-## `plugins` property — `transformers.py:62`
+## `plugins` property - `transformers.py:62`
 
 Returns all loaded plugins sorted by **ascending** priority (OVOS-TRANSFORM §4):
 
@@ -66,9 +66,9 @@ Returns all loaded plugins sorted by **ascending** priority (OVOS-TRANSFORM §4)
 sorted(self.loaded_plugins.values(), key=lambda k: k.priority)
 ```
 
-Lower `priority` number → called first (default 50). A plugin with `priority=1` runs first; later plugins see and may override its audio and context. An explicit `"order"` list in the config section wins over priorities. The service is the canonical `AudioTransformersService` from `ovos_plugin_manager.transformer_services`; full contract → [`ovos-plugin-manager/docs/transformers.md`](../../ovos-plugin-manager/docs/transformers.md).
+Lower `priority` number → called first (default 50). A plugin with `priority=1` runs first, later plugins see and may override its audio and context. An explicit `"order"` list in the config section wins over priorities. The service is the canonical `AudioTransformersService` from `ovos_plugin_manager.transformer_services`, full contract → [`ovos-plugin-manager/docs/transformers.md`](../../ovos-plugin-manager/docs/transformers.md).
 
-**Split deployments:** ovos-stt-server, hivemind-audio-binary-protocol and the HiveMind satellites can run audio transformers too — enable each plugin in exactly one place or audio is processed twice.
+**Split deployments:** ovos-stt-server, hivemind-audio-binary-protocol and the HiveMind satellites can run audio transformers too - enable each plugin in exactly one place or audio is processed twice.
 
 ---
 
@@ -76,27 +76,27 @@ Lower `priority` number → called first (default 50). A plugin with `priority=1
 
 The voice loop calls these on each audio chunk to inform plugins of the audio type. Plugins implement the corresponding `feed_*_chunk()` method.
 
-### `feed_audio(chunk)` — `transformers.py:84`
+### `feed_audio(chunk)` - `transformers.py:84`
 
-Called for **ambient audio** — chunks where no hotword is active and no command is being recorded. Invoked in states: `DETECT_WAKEWORD`, `WAITING_CMD`, `PRE_WAKE_VAD`, `BEFORE_COMMAND`, `CONFIRMATION`.
+Called for **ambient audio** - chunks where no hotword is active and no command is being recorded. Invoked in states: `DETECT_WAKEWORD`, `WAITING_CMD`, `PRE_WAKE_VAD`, `BEFORE_COMMAND`, `CONFIRMATION`.
 
 Calls `module.feed_audio_chunk(chunk)` for each plugin in priority order.
 
-### `feed_hotword(chunk)` — `transformers.py:92`
+### `feed_hotword(chunk)` - `transformers.py:92`
 
 Called for the chunk in which a hotword/wake-word was detected. Allows plugins to process or log the moment of wakeword detection.
 
 Calls `module.feed_hotword_chunk(chunk)` for each plugin.
 
-### `feed_speech(chunk)` — `transformers.py:100`
+### `feed_speech(chunk)` - `transformers.py:100`
 
 Called for each chunk while the user is speaking an active command (`IN_COMMAND`, `RECORDING`).
 
-Calls `module.feed_speech_chunk(chunk)` for each plugin. Exceptions are caught and logged — `transformers.py:108`.
+Calls `module.feed_speech_chunk(chunk)` for each plugin. Exceptions are caught and logged - `transformers.py:108`.
 
 ---
 
-## `transform(chunk)` → `(bytes, dict)` — `transformers.py:111`
+## `transform(chunk)` → `(bytes, dict)` - `transformers.py:111`
 
 Called once per utterance at the end of a command (`AFTER_COMMAND`), after all speech audio has been recorded.
 
@@ -105,12 +105,12 @@ audio_bytes, context = svc.transform(chunk)
 # context is merged into message.context for recognizer_loop:utterance
 ```
 
-For each plugin in priority order — `transformers.py:120`:
+For each plugin in priority order - `transformers.py:120`:
 1. `module.feed_speech_utterance(chunk)` → plugin receives the complete utterance audio
 2. `module.transform(chunk)` → returns `(transformed_chunk, metadata_dict)`
-3. `context = merge_dict(context, metadata_dict)` — later plugins' keys override earlier ones
+3. `context = merge_dict(context, metadata_dict)` - later plugins' keys override earlier ones
 
-Default context initialised at the start of `transform()` — `transformers.py:117`:
+Default context initialised at the start of `transform()` - `transformers.py:117`:
 
 ```python
 {
@@ -132,7 +132,7 @@ The merged context becomes `message.context` in `recognizer_loop:utterance`.
 
 ---
 
-## `shutdown()` — `transformers.py:74`
+## `shutdown()` - `transformers.py:74`
 
 Calls `module.shutdown()` on each loaded plugin in priority order. Exceptions are caught and logged as warnings.
 
@@ -199,3 +199,6 @@ assert ctx["destination"] == ["skills"]
 ```
 
 See `test/unittests/test_transformers.py` for complete test coverage.
+
+---
+[← Service](service.md) · [Home](index.md) · [Plugins →](plugins.md)

--- a/docs/voice-loop.md
+++ b/docs/voice-loop.md
@@ -9,18 +9,18 @@ The `DinkumVoiceLoop` is the core finite-state machine (FSM) of `ovos-dinkum-lis
 
 ## Enums
 
-### `ListeningMode` — `voice_loop.py:49`
+### `ListeningMode` - `voice_loop.py:49`
 
 Global operating mode. Set once at startup from config. Controls which FSM states are reachable.
 
 | Value | Config trigger | Description |
 |---|---|---|
 | `WAKEWORD` | default | Only listen after a wake word is detected |
-| `CONTINUOUS` | `listener.continuous_listen: true` | Always listen; no wake word required |
+| `CONTINUOUS` | `listener.continuous_listen: true` | Always listen, no wake word required |
 | `HYBRID` | `listener.hybrid_listen: true` | Always listen but also detect hotwords |
-| `SLEEPING` | programmatic | Suppressed; only wakeup words are checked |
+| `SLEEPING` | programmatic | Suppressed, only wakeup words are checked |
 
-### `ListeningState` — `voice_loop.py:32`
+### `ListeningState` - `voice_loop.py:32`
 
 Internal FSM state. Transitions on every audio chunk in `DinkumVoiceLoop.run()`.
 
@@ -29,30 +29,30 @@ Internal FSM state. Transitions on every audio chunk in `DinkumVoiceLoop.run()`.
 | `PRE_WAKE_VAD` | `"pre_wake_vad"` | Gate wakeword detection on VAD speech presence |
 | `DETECT_WAKEWORD` | `"wakeword"` | Feed audio to hotword engines waiting for a listen word |
 | `WAITING_CMD` | `"continuous"` | Continuous mode: accumulate audio until speech begins |
-| `CONFIRMATION` | `"confirmation"` | Playing listen sound; no STT buffering yet |
+| `CONFIRMATION` | `"confirmation"` | Playing listen sound, no STT buffering yet |
 | `BEFORE_COMMAND` | `"before_cmd"` | Waiting for VAD to confirm speech started |
-| `IN_COMMAND` | `"in_cmd"` | VAD confirmed speech; streaming audio to STT |
-| `AFTER_COMMAND` | `"after_cmd"` | Silence end detected; finalise STT and fire callbacks |
-| `RECORDING` | `"recording"` | Free recording mode; exits on stop word or max silence |
-| `SLEEPING` | `"sleeping"` | Suppressed; only wakeup words are active |
-| `CHECK_WAKE_UP` | `"wake_up"` | Wake word heard while sleeping; waiting for wakeup word |
+| `IN_COMMAND` | `"in_cmd"` | VAD confirmed speech, streaming audio to STT |
+| `AFTER_COMMAND` | `"after_cmd"` | Silence end detected, finalise STT and fire callbacks |
+| `RECORDING` | `"recording"` | Free recording mode, exits on stop word or max silence |
+| `SLEEPING` | `"sleeping"` | Suppressed, only wakeup words are active |
+| `CHECK_WAKE_UP` | `"wake_up"` | Wake word heard while sleeping, waiting for wakeup word |
 
 ---
 
-## `VoiceLoop` — `voice_loop.py:58`
+## `VoiceLoop` - `voice_loop.py:58`
 
 Abstract base `@dataclass` holding the five required plugin references. Subclasses must implement `start()`, `run()`, and `stop()`.
 
 | Field | Type | Description |
 |---|---|---|
-| `mic` | `Microphone` | Microphone plugin — source of raw audio chunks |
+| `mic` | `Microphone` | Microphone plugin - source of raw audio chunks |
 | `hotwords` | `HotwordContainer` | Wake word / hotword engine manager |
 | `stt` | `StreamingSTT` | Primary STT plugin |
 | `fallback_stt` | `StreamingSTT` | Fallback STT plugin (may be `None`) |
 | `vad` | `VADEngine` | Voice activity detection plugin |
 | `transformers` | `AudioTransformersService` | Audio transformer pipeline |
 
-### `VoiceLoop.debiased_energy(audio_data, sample_width)` — `voice_loop.py:76`
+### `VoiceLoop.debiased_energy(audio_data, sample_width)` - `voice_loop.py:76`
 
 Static method. Computes the RMS energy of an audio chunk after subtracting the mean (DC bias removal). Uses `audioop.rms` twice: once to get the bias value, once to compute RMS of the bias-corrected signal.
 
@@ -60,7 +60,7 @@ A DC-biased signal (constant value) returns `0` energy even if the raw bytes are
 
 ---
 
-## `DinkumVoiceLoop` — `voice_loop.py:106`
+## `DinkumVoiceLoop` - `voice_loop.py:106`
 
 Concrete FSM implementation. A `@dataclass` that extends `VoiceLoop`.
 
@@ -93,27 +93,27 @@ Internal timer fields (countdown per chunk): `speech_seconds_left`, `silence_sec
 
 Internal audio buffers: `hotword_chunks` (deque, maxlen=`num_hotword_keep_chunks`), `stt_chunks` (deque, maxlen varies by mode), `stt_audio_bytes` (accumulated raw bytes).
 
-### Callbacks — `voice_loop.py:132`
+### Callbacks - `voice_loop.py:132`
 
 All callbacks are wired by `OVOSDinkumVoiceService._init_voice_loop()`.
 
 | Callback | Signature | Fires when |
 |---|---|---|
-| `wake_callback` | `() → None` | Wake word detected or `start_recording()` called — triggers `recognizer_loop:record_begin` |
-| `wakeup_callback` | `() → None` | Wakeup word confirmed — triggers `mycroft.awoken` |
-| `text_callback` | `(utts: List[Tuple[str, float]], ctx: dict) → None` | STT complete; `utts` is a ranked list of `(transcript, confidence)` |
+| `wake_callback` | `() → None` | Wake word detected or `start_recording()` called - triggers `recognizer_loop:record_begin` |
+| `wakeup_callback` | `() → None` | Wakeup word confirmed - triggers `mycroft.awoken` |
+| `text_callback` | `(utts: List[Tuple[str, float]], ctx: dict) → None` | STT complete, `utts` is a ranked list of `(transcript, confidence)` |
 | `stt_audio_callback` | `(audio: bytes, ctx: dict) → None` | After `AFTER_COMMAND`, with raw utterance audio |
 | `recording_audio_callback` | `(audio: bytes, metadata: dict) → None` | After `stop_recording()`, with full recording audio |
 | `listenword_audio_callback` | `(audio: bytes, ww_data: dict) → None` | Listen word detected (includes hotword audio window) |
 | `hotword_audio_callback` | `(audio: bytes, ww_data: dict) → None` | Non-listen hotword detected |
 | `stopword_audio_callback` | `(audio: bytes, ww_data: dict) → None` | Stop word detected during `RECORDING` |
 | `wakeupword_audio_callback` | `(audio: bytes, ww_data: dict) → None` | Wakeup word detected while sleeping |
-| `record_end_callback` | `() → None` | Recording ended — triggers `recognizer_loop:record_end` |
+| `record_end_callback` | `() → None` | Recording ended - triggers `recognizer_loop:record_end` |
 | `chunk_callback` | `(ChunkInfo) → None` | Called on every audio chunk regardless of state |
 
 ---
 
-## State Machine — Normal Wakeword Flow
+## State Machine - Normal Wakeword Flow
 
 ```
 PRE_WAKE_VAD  (if vad_pre_wake_enabled)
@@ -139,7 +139,7 @@ DETECT_WAKEWORD
 
 ---
 
-## State Machine — Continuous/Hybrid Flow
+## State Machine - Continuous/Hybrid Flow
 
 ```
 WAITING_CMD
@@ -151,7 +151,7 @@ IN_COMMAND → AFTER_COMMAND → WAITING_CMD
 
 ---
 
-## State Machine — Sleep Flow
+## State Machine - Sleep Flow
 
 ```
 SLEEPING
@@ -164,7 +164,7 @@ CHECK_WAKE_UP
 
 ---
 
-## State Machine — Recording Mode
+## State Machine - Recording Mode
 
 ```
 RECORDING  (entered via start_recording())
@@ -176,119 +176,119 @@ RECORDING  (entered via start_recording())
 
 ## Method Reference
 
-### `DinkumVoiceLoop.start()` — `voice_loop.py:164`
+### `DinkumVoiceLoop.start()` - `voice_loop.py:164`
 
 Reads `listener.continuous_listen` and `listener.hybrid_listen` from config to set `listen_mode`. Sets initial `state` (`PRE_WAKE_VAD` if enabled, else `DETECT_WAKEWORD`). Resets `last_ww` timer.
 
-### `DinkumVoiceLoop.run()` — `voice_loop.py:205`
+### `DinkumVoiceLoop.run()` - `voice_loop.py:205`
 
 Main loop. Reads from `mic.read_chunk()` until `stop()` is called. On each chunk:
-1. Zero-fills the chunk if `is_muted` — `voice_loop.py:243`
-2. Resets `_chunk_info.is_speech` and `energy` — `voice_loop.py:247`
+1. Zero-fills the chunk if `is_muted` - `voice_loop.py:243`
+2. Resets `_chunk_info.is_speech` and `energy` - `voice_loop.py:247`
 3. Dispatches to the appropriate FSM handler
-4. Calls `chunk_callback(ChunkInfo)` with RMS energy — `voice_loop.py:312`
+4. Calls `chunk_callback(ChunkInfo)` with RMS energy - `voice_loop.py:312`
 
 State transitions during `DETECT_WAKEWORD`:
 - `CONTINUOUS` mode → immediately transition to `WAITING_CMD`
 - else check `_detect_ww()` then `_detect_hot()` then feed transformers
-- if `vad_pre_wake_enabled` and no WW within 5s → return to `PRE_WAKE_VAD` — `voice_loop.py:276`
+- if `vad_pre_wake_enabled` and no WW within 5s → return to `PRE_WAKE_VAD` - `voice_loop.py:276`
 
-### `DinkumVoiceLoop._pre_wake_vad(chunk)` — `voice_loop.py:190`
+### `DinkumVoiceLoop._pre_wake_vad(chunk)` - `voice_loop.py:190`
 
 In `PRE_WAKE_VAD` state. Calls `vad.is_silence()`. On speech detected: transitions to `DETECT_WAKEWORD`, records `_vad_window_start`, appends chunk to `hotword_chunks`. On silence: feeds `transformers.feed_audio()`.
 
-### `DinkumVoiceLoop._detect_ww(chunk)` — `voice_loop.py:512`
+### `DinkumVoiceLoop._detect_ww(chunk)` - `voice_loop.py:512`
 
 1. Appends chunk to both `hotword_chunks` and `stt_chunks`
 2. Calls `hotwords.update(chunk)` with state `LISTEN`
 3. Calls `hotwords.found()` → returns WW name or `None`
-4. On detection: calls `hotwords.verify()` with the accumulated wake-word audio; if any verifier plugin rejects it, the detection is discarded and the method returns `False`
+4. On detection: calls `hotwords.verify()` with the accumulated wake-word audio, if any verifier plugin rejects it, the detection is discarded and the method returns `False`
 5. Fires `listenword_audio_callback` with accumulated `hotword_chunks`
 6. Fires `wake_callback`
-7. If sleeping → `CHECK_WAKE_UP`; else if sound → `CONFIRMATION`; else → `BEFORE_COMMAND`
+7. If sleeping → `CHECK_WAKE_UP`, else if sound → `CONFIRMATION`, else → `BEFORE_COMMAND`
 8. Starts STT stream: `stt.stream_start()` (and `fallback_stt.stream_start()`)
 9. Returns `True` if detected
 
-### `DinkumVoiceLoop._confirmation_sound(chunk)` — `voice_loop.py:613`
+### `DinkumVoiceLoop._confirmation_sound(chunk)` - `voice_loop.py:613`
 
 In `CONFIRMATION` state. If `instant_listen=True`, immediately transitions to `BEFORE_COMMAND` and calls `_before_cmd()`. Otherwise, decrements `confirmation_seconds_left` and transitions to `BEFORE_COMMAND` when it reaches zero.
 
-### `DinkumVoiceLoop._before_cmd(chunk)` — `voice_loop.py:631`
+### `DinkumVoiceLoop._before_cmd(chunk)` - `voice_loop.py:631`
 
-In `BEFORE_COMMAND` state. Streams every chunk from `stt_chunks` into `stt.stream_data()`. Decrements `timeout_seconds_with_silence_left`; if expired → `AFTER_COMMAND`. Checks VAD: on `speech_seconds` of speech → `IN_COMMAND`.
+In `BEFORE_COMMAND` state. Streams every chunk from `stt_chunks` into `stt.stream_data()`. Decrements `timeout_seconds_with_silence_left`, if expired → `AFTER_COMMAND`. Checks VAD: on `speech_seconds` of speech → `IN_COMMAND`.
 
-### `DinkumVoiceLoop._in_cmd(chunk)` — `voice_loop.py:678`
+### `DinkumVoiceLoop._in_cmd(chunk)` - `voice_loop.py:678`
 
 In `IN_COMMAND` state. Feeds `transformers.feed_speech()`. Streams audio to `stt.stream_data()`. Checks VAD: on `silence_seconds` of silence → `AFTER_COMMAND`. If `timeout_seconds_left` reaches zero → `AFTER_COMMAND`.
 
-### `DinkumVoiceLoop._after_cmd(chunk)` — `voice_loop.py:818`
+### `DinkumVoiceLoop._after_cmd(chunk)` - `voice_loop.py:818`
 
 In `AFTER_COMMAND` state. Sequence:
-1. `transformers.transform(chunk)` → `(chunk, stt_context)` — `voice_loop.py:827`
-2. If `isinstance(stt, FakeStreamingSTT) and remove_silence` → `_vad_remove_silence()` — `voice_loop.py:828`
-3. `_get_tx(stt_context)` → `(utts, stt_context)` — `voice_loop.py:831`
-4. `stt_audio_callback(stt_audio_bytes, stt_context)` — `voice_loop.py:838`
-5. `record_end_callback()` — `voice_loop.py:843`
-6. `text_callback(utts, stt_context)` — `voice_loop.py:848`
-7. Transition to `DETECT_WAKEWORD` or `WAITING_CMD` — `voice_loop.py:851`
-8. `hotwords.reset()` — `voice_loop.py:862`
-9. Optional `vad.reset()` — `voice_loop.py:866`
+1. `transformers.transform(chunk)` → `(chunk, stt_context)` - `voice_loop.py:827`
+2. If `isinstance(stt, FakeStreamingSTT) and remove_silence` → `_vad_remove_silence()` - `voice_loop.py:828`
+3. `_get_tx(stt_context)` → `(utts, stt_context)` - `voice_loop.py:831`
+4. `stt_audio_callback(stt_audio_bytes, stt_context)` - `voice_loop.py:838`
+5. `record_end_callback()` - `voice_loop.py:843`
+6. `text_callback(utts, stt_context)` - `voice_loop.py:848`
+7. Transition to `DETECT_WAKEWORD` or `WAITING_CMD` - `voice_loop.py:851`
+8. `hotwords.reset()` - `voice_loop.py:862`
+9. Optional `vad.reset()` - `voice_loop.py:866`
 
-### `DinkumVoiceLoop._get_tx(stt_context)` — `voice_loop.py:739`
+### `DinkumVoiceLoop._get_tx(stt_context)` - `voice_loop.py:739`
 
 Attempts transcription:
-1. If `stt_context["stt_lang"]` present → `_validate_lang()` — updates `stt.stream.language`
+1. If `stt_context["stt_lang"]` present → `_validate_lang()` - updates `stt.stream.language`
 2. `stt.transcribe(lang=lang)` → list of `(text, confidence)` tuples
 3. If empty and `fallback_stt` present → `fallback_stt.transcribe(lang=lang)`
 4. Filter below `min_stt_confidence` (always keep at least 1)
 5. Truncate to `max_transcripts`
 6. Returns `(filtered, stt_context)` with `stt_context["transcriptions"]` populated
 
-### `DinkumVoiceLoop._validate_lang(lang)` — `voice_loop.py:717`
+### `DinkumVoiceLoop._validate_lang(lang)` - `voice_loop.py:717`
 
 Validates a language code against `config["lang"]` + `config["secondary_langs"]`. Comparison uses only the primary subtag (e.g. `"en"` from `"en-us"`). Returns validated lang or the default if unknown.
 
-### `DinkumVoiceLoop._vad_remove_silence()` — `voice_loop.py:792`
+### `DinkumVoiceLoop._vad_remove_silence()` - `voice_loop.py:792`
 
 Only executes when `isinstance(self.stt, FakeStreamingSTT) and self.remove_silence`. Calls `vad.extract_speech(stt_audio_bytes)`. If the result is ≥1 second, replaces `stt.stream.buffer` with the trimmed audio. Skips if the original recording is under 1 second.
 
-### `DinkumVoiceLoop._wait_cmd(chunk)` — `voice_loop.py:578`
+### `DinkumVoiceLoop._wait_cmd(chunk)` - `voice_loop.py:578`
 
-In `WAITING_CMD` state (continuous mode). Checks VAD. On speech: decrements `speech_seconds_left`; when exhausted → starts STT stream and transitions to `IN_COMMAND`. On silence: resets `speech_seconds_left`, checks for hotwords via `_detect_hot()`, feeds `transformers.feed_audio()`.
+In `WAITING_CMD` state (continuous mode). Checks VAD. On speech: decrements `speech_seconds_left`, when exhausted → starts STT stream and transitions to `IN_COMMAND`. On silence: resets `speech_seconds_left`, checks for hotwords via `_detect_hot()`, feeds `transformers.feed_audio()`.
 
-### `DinkumVoiceLoop._in_recording(chunk)` — `voice_loop.py:382`
+### `DinkumVoiceLoop._in_recording(chunk)` - `voice_loop.py:382`
 
-In `RECORDING` state. Checks for stop words via `hotwords.found()`. On stop word: calls `stop_recording()`, fires `stopword_audio_callback`. Otherwise: checks VAD and accumulates audio; decrements `recording_seconds_with_silence_left` on silence; calls `stop_recording()` on timeout.
+In `RECORDING` state. Checks for stop words via `hotwords.found()`. On stop word: calls `stop_recording()`, fires `stopword_audio_callback`. Otherwise: checks VAD and accumulates audio, decrements `recording_seconds_with_silence_left` on silence, calls `stop_recording()` on timeout.
 
-### `DinkumVoiceLoop._detect_wakeup(chunk)` — `voice_loop.py:442`
+### `DinkumVoiceLoop._detect_wakeup(chunk)` - `voice_loop.py:442`
 
 In `CHECK_WAKE_UP` state. Updates hotword engines with state `WAKEUP`. On wakeup word: transitions to `DETECT_WAKEWORD`, fires `wakeup_callback` and `wakeupword_audio_callback`. If `last_ww` is more than 10 seconds ago → returns to `SLEEPING`.
 
-### `DinkumVoiceLoop.reset_state()` — `voice_loop.py:318`
+### `DinkumVoiceLoop.reset_state()` - `voice_loop.py:318`
 
 Resets to default state for current `listen_mode`:
 - `CONTINUOUS` → `WAITING_CMD`, hotwords state → `HOTWORD`
 - `WAKEWORD` / `HYBRID` → `DETECT_WAKEWORD`, hotwords state → `LISTEN`
 
-### `DinkumVoiceLoop.go_to_sleep()` — `voice_loop.py:335`
+### `DinkumVoiceLoop.go_to_sleep()` - `voice_loop.py:335`
 
 Sets `state = SLEEPING`.
 
-### `DinkumVoiceLoop.start_recording(filename)` — `voice_loop.py:353`
+### `DinkumVoiceLoop.start_recording(filename)` - `voice_loop.py:353`
 
 Sets `state = RECORDING`, resets `recording_seconds_with_silence_left`, fires `wake_callback` (to emit `record_begin`).
 
-### `DinkumVoiceLoop.stop_recording()` — `voice_loop.py:367`
+### `DinkumVoiceLoop.stop_recording()` - `voice_loop.py:367`
 
 Fires `recording_audio_callback(stt_audio_bytes, {"recording_name": filename})`, then `record_end_callback()`, then `reset_state()`.
 
-### `DinkumVoiceLoop.stop()` — `voice_loop.py:873`
+### `DinkumVoiceLoop.stop()` - `voice_loop.py:873`
 
 Sets `_is_running = False`. The `run()` loop exits on the next iteration.
 
 ---
 
-## `ChunkInfo` — `voice_loop.py:93`
+## `ChunkInfo` - `voice_loop.py:93`
 
 Dataclass passed to `chunk_callback` on every audio chunk.
 
@@ -304,10 +304,10 @@ Dataclass passed to `chunk_callback` on every audio chunk.
 
 When `listener.vad_pre_wake_enabled: true` in config:
 
-1. Loop starts in `PRE_WAKE_VAD` — `voice_loop.py:215`
+1. Loop starts in `PRE_WAKE_VAD` - `voice_loop.py:215`
 2. Each chunk is sent to `transformers.feed_audio()` unless VAD detects speech
-3. On speech: `_vad_window_start` is set, chunk appended to `hotword_chunks`, state → `DETECT_WAKEWORD` — `voice_loop.py:199`
-4. If no wake word detected within 5 seconds of VAD activation → back to `PRE_WAKE_VAD` — `voice_loop.py:276`
+3. On speech: `_vad_window_start` is set, chunk appended to `hotword_chunks`, state → `DETECT_WAKEWORD` - `voice_loop.py:199`
+4. If no wake word detected within 5 seconds of VAD activation → back to `PRE_WAKE_VAD` - `voice_loop.py:276`
 
 This reduces CPU usage from hotword engines when the environment is silent.
 
@@ -315,7 +315,7 @@ This reduces CPU usage from hotword engines when the environment is silent.
 
 ## STT Transcription Flow
 
-Full sequence after `AFTER_COMMAND` — `voice_loop.py:818`:
+Full sequence after `AFTER_COMMAND` - `voice_loop.py:818`:
 
 ```
 _after_cmd()
@@ -356,6 +356,9 @@ loop.stt_chunks = deque(maxlen=3)
 loop.stt_audio_bytes = bytes()
 ```
 
-Using `seconds_per_chunk=0.256` ensures timers (e.g. `speech_seconds_left=0.3`) expire within 1–2 chunks in tests.
+Using `seconds_per_chunk=0.256` ensures timers (e.g. `speech_seconds_left=0.3`) expire within 1-2 chunks in tests.
 
 See `test/unittests/test_voice_loop_methods.py` for comprehensive state-method tests.
+
+---
+[Home](index.md) · [Hotwords →](hotwords.md)


### PR DESCRIPTION
Rewrites README.md and the docs/*.md pages in Simplified Technical English for clarity: shorter sentences, active voice, no em dashes or semicolons, and a related-projects section and license section added to the README. Adds the footer navigation convention (prev/home/next links) across the docs/ page set.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a concise project overview, documentation links, related projects, and improved credits and license formatting.
  * Standardized punctuation, headings, terminology, and formatting across the documentation.
  * Added navigation links and footer improvements throughout the documentation.
  * Clarified plugin ordering, deployment behavior, feed methods, metadata merging, and service references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->