### PR TITLE
feat: run ServiceInstaller so plugins install into the listener env over the bus

### DIFF
--- a/ovos_dinkum_listener/service.py
+++ b/ovos_dinkum_listener/service.py
@@ -47,6 +47,7 @@ from ovos_plugin_manager.wakewords import (
 )
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG, log_deprecation
+from ovos_utils.skill_installer import ServiceInstaller
 from ovos_utils.sound import get_sound_duration
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap, ProcessState
 
@@ -479,6 +480,8 @@ class OVOSDinkumVoiceService(Thread):
         """
         Stop the voice_loop and trigger service shutdown
         """
+        if getattr(self, "installer", None):
+            self.installer.shutdown()
         self.status.set_stopping()
         self._stopping = True
         if self.voice_loop.running:
@@ -525,6 +528,7 @@ class OVOSDinkumVoiceService(Thread):
         self.config.set_config_update_handlers(self.bus)
         self.config.set_config_watcher(self.reload_configuration)
         LOG.info("Connected to Mycroft Core message bus")
+        self.installer = ServiceInstaller(self.bus, service_name="ovos_dinkum_listener")
 
     def _report_service_state(self, message):
         """Response to service state requests"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 dependencies = [
     "ovos-plugin-manager>=2.10.0a1,<3.0.0",
-    "ovos-utils>=0.8.4,<1.0.0",
+    "ovos-utils>=0.8.5,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
     "ovos_bus_client>=2.5.1a1,<3.0.0",
     "ovos-spec-tools>=0.16.1a2",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

## What
Run `ovos_utils.skill_installer.ServiceInstaller` in the listener service so ovos-dinkum-listener installs STT/VAD/wake-word plugins into its own environment over the message bus. Answers broadcast `ovos.pip.install` / `.uninstall` and targeted `ovos.pip.install.ovos_dinkum_listener` / `.uninstall.ovos_dinkum_listener`, replying on the base `ovos.pip.install.complete` / `.failed` topics.

## Why
In split/containerised deployments each service owns a separate venv. An STT/VAD/wake-word plugin must install into the process that loads it — the listener. One of a fleet of companion PRs (audio, gui, PHAL, core); ovos-webui's plugin browser routes each plugin family to the owning service by these topics.

## service_name convention
`service_name="ovos_dinkum_listener"` — the module/process name with underscores, following ServiceInstaller's own documented convention. The web-ui routing map and every companion PR use this same form.

## Safety
Gated by `skills.installer.allow_pip` — off by default. Cleanly unregistered on stop.
